### PR TITLE
Validate signing roots for CommitteeRunner

### DIFF
--- a/ssv/aggregator.go
+++ b/ssv/aggregator.go
@@ -199,22 +199,22 @@ func (r *AggregatorRunner) ProcessPostConsensus(signedMsg *types.PartialSignatur
 	return nil
 }
 
-func (r *AggregatorRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	return []ssz.HashRoot{types.SSZUint64(r.GetState().StartingDuty.DutySlot())}, types.DomainSelectionProof, nil
+func (r *AggregatorRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
+	return []ssz.HashRoot{types.SSZUint64(r.GetState().StartingDuty.DutySlot())}, []phase0.DomainType{types.DomainSelectionProof}, nil
 }
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
-func (r *AggregatorRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
+func (r *AggregatorRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
 	cd, err := types.CreateConsensusData(r.GetState().DecidedValue)
 	if err != nil {
-		return nil, types.DomainError, errors.Wrap(err, "could not create consensus data")
+		return nil, []phase0.DomainType{}, errors.Wrap(err, "could not create consensus data")
 	}
 	aggregateAndProof, err := cd.GetAggregateAndProof()
 	if err != nil {
-		return nil, phase0.DomainType{}, errors.Wrap(err, "could not get aggregate and proof")
+		return nil, []phase0.DomainType{}, errors.Wrap(err, "could not get aggregate and proof")
 	}
 
-	return []ssz.HashRoot{aggregateAndProof}, types.DomainAggregateAndProof, nil
+	return []ssz.HashRoot{aggregateAndProof}, []phase0.DomainType{types.DomainAggregateAndProof}, nil
 }
 
 // executeDuty steps:

--- a/ssv/proposer.go
+++ b/ssv/proposer.go
@@ -83,7 +83,6 @@ func (r *ProposerRunner) ProcessPreConsensus(signedMsg *types.PartialSignatureMe
 
 	duty := r.GetState().StartingDuty.(*types.BeaconDuty)
 
-
 	// get block data
 	obj, ver, err := r.GetBeaconNode().GetBeaconBlock(duty.Slot, r.GetShare().Graffiti, fullSig)
 	if err != nil {
@@ -226,31 +225,31 @@ func (r *ProposerRunner) decidedBlindedBlock() bool {
 	return err == nil
 }
 
-func (r *ProposerRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
+func (r *ProposerRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
 	epoch := r.BaseRunner.BeaconNetwork.EstimatedEpochAtSlot(r.GetState().StartingDuty.DutySlot())
-	return []ssz.HashRoot{types.SSZUint64(epoch)}, types.DomainRandao, nil
+	return []ssz.HashRoot{types.SSZUint64(epoch)}, []phase0.DomainType{types.DomainRandao}, nil
 }
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
-func (r *ProposerRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
+func (r *ProposerRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
 
 	consensusData, err := types.CreateConsensusData(r.GetState().DecidedValue)
 	if err != nil {
-		return nil, phase0.DomainType{}, errors.Wrap(err, "could not create consensus data")
+		return nil, []phase0.DomainType{}, errors.Wrap(err, "could not create consensus data")
 	}
 	if r.decidedBlindedBlock() {
 		_, data, err := consensusData.GetBlindedBlockData()
 		if err != nil {
-			return nil, phase0.DomainType{}, errors.Wrap(err, "could not get blinded block data")
+			return nil, []phase0.DomainType{}, errors.Wrap(err, "could not get blinded block data")
 		}
-		return []ssz.HashRoot{data}, types.DomainProposer, nil
+		return []ssz.HashRoot{data}, []phase0.DomainType{types.DomainProposer}, nil
 	}
 
 	_, data, err := consensusData.GetBlockData()
 	if err != nil {
-		return nil, phase0.DomainType{}, errors.Wrap(err, "could not get block data")
+		return nil, []phase0.DomainType{}, errors.Wrap(err, "could not get block data")
 	}
-	return []ssz.HashRoot{data}, types.DomainProposer, nil
+	return []ssz.HashRoot{data}, []phase0.DomainType{types.DomainProposer}, nil
 }
 
 // executeDuty steps:

--- a/ssv/runner.go
+++ b/ssv/runner.go
@@ -35,9 +35,9 @@ type Runner interface {
 	ProcessPostConsensus(signedMsg *types.PartialSignatureMessages) error
 
 	// expectedPreConsensusRootsAndDomain an INTERNAL function, returns the expected pre-consensus roots to sign
-	expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, spec.DomainType, error)
+	expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, []spec.DomainType, error)
 	// expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
-	expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, spec.DomainType, error)
+	expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, []spec.DomainType, error)
 	// executeDuty an INTERNAL function, executes a duty.
 	executeDuty(duty types.Duty) error
 }

--- a/ssv/runner_validations.go
+++ b/ssv/runner_validations.go
@@ -97,7 +97,7 @@ func (b *BaseRunner) verifyExpectedRoot(runner Runner, psigMsgs *types.PartialSi
 		for i, rootI := range expectedRootObjs {
 			d, err := runner.GetBeaconNode().DomainData(epoch, domains[i])
 			if err != nil {
-				return nil, errors.Wrap(err, "could not get pre consensus root domain")
+				return nil, errors.Wrap(err, "could not get domain to compute ETH signing root")
 			}
 
 			r, err := types.ComputeETHSigningRoot(rootI, d)

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_root_then_quorum/attester and sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_root_then_quorum/attester and sync committee.json
@@ -8,9 +8,6 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt",
 														"2": "gMXzIoe/QJBrH+ntuAoJ+kvr4qhj4VUmWphfsoLyOQ2VYjwvIOqDtLlXstFKbKXSCqNmxYecfX8xts3jWxcfHILOEgavz6rA8kiThsqlCSHWx3yDbjuBrISi9kU2a0a4",
@@ -20,9 +17,6 @@
 														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6",
 														"2": "gfJwcjkKd72XrqH1PyfpL6g2zmLhvX99oMlpNc5C6WA1jATfEYuSPM3owCYPdiJ1FJxrFPA329rGf64xW1eMgrW18YZWOresqKvYkg4wk9jt9EQ6+tLUzi9oKiLHb/CI",
 														"3": "rOeX7b6mKw1pLe52wF1kzMz9lrvN/iTiGUenHb2ISLUyEhMxt1o7ZAdiR0LXX9IqGRg8VRykIK6AE391GwqCGtLsW/29zLhpmQf3nmjVqdHlHOffJP+A4ntb+cr0sHAF"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_root_then_quorum/attester.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_root_then_quorum/attester.json
@@ -8,9 +8,6 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt",
 														"2": "gMXzIoe/QJBrH+ntuAoJ+kvr4qhj4VUmWphfsoLyOQ2VYjwvIOqDtLlXstFKbKXSCqNmxYecfX8xts3jWxcfHILOEgavz6rA8kiThsqlCSHWx3yDbjuBrISi9kU2a0a4",

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_root_then_quorum/sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_root_then_quorum/sync committee.json
@@ -12,9 +12,6 @@
 														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6",
 														"2": "gfJwcjkKd72XrqH1PyfpL6g2zmLhvX99oMlpNc5C6WA1jATfEYuSPM3owCYPdiJ1FJxrFPA329rGf64xW1eMgrW18YZWOresqKvYkg4wk9jt9EQ6+tLUzi9oKiLHb/CI",
 														"3": "rOeX7b6mKw1pLe52wF1kzMz9lrvN/iTiGUenHb2ISLUyEhMxt1o7ZAdiR0LXX9IqGRg8VRykIK6AE391GwqCGtLsW/29zLhpmQf3nmjVqdHlHOffJP+A4ntb+cr0sHAF"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_roots/attester and sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_roots/attester and sync committee.json
@@ -8,17 +8,11 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
 														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_roots/attester.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_roots/attester.json
@@ -8,9 +8,6 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt"
 												}

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_roots/sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_duplicate_msg_different_roots/sync committee.json
@@ -10,9 +10,6 @@
 										"1": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
 														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_expected_roots/attester and sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_expected_roots/attester and sync committee.json
@@ -6,16 +6,7 @@
 								"Quorum": 3
 						},
 						"PostConsensusContainer": {
-								"Signatures": {
-										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
-												}
-										}
-								},
+								"Signatures": {},
 								"Quorum": 3
 						},
 						"RunningInstance": {

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_expected_roots/attester.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_expected_roots/attester.json
@@ -6,13 +6,7 @@
 								"Quorum": 3
 						},
 						"PostConsensusContainer": {
-								"Signatures": {
-										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												}
-										}
-								},
+								"Signatures": {},
 								"Quorum": 3
 						},
 						"RunningInstance": {

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_expected_roots/sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_expected_roots/sync committee.json
@@ -6,13 +6,7 @@
 								"Quorum": 3
 						},
 						"PostConsensusContainer": {
-								"Signatures": {
-										"1": {
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
-												}
-										}
-								},
+								"Signatures": {},
 								"Quorum": 3
 						},
 						"RunningInstance": {

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_then_quorum/attester and sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_then_quorum/attester and sync committee.json
@@ -8,9 +8,6 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt",
 														"2": "gMXzIoe/QJBrH+ntuAoJ+kvr4qhj4VUmWphfsoLyOQ2VYjwvIOqDtLlXstFKbKXSCqNmxYecfX8xts3jWxcfHILOEgavz6rA8kiThsqlCSHWx3yDbjuBrISi9kU2a0a4",
@@ -20,9 +17,6 @@
 														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6",
 														"2": "gfJwcjkKd72XrqH1PyfpL6g2zmLhvX99oMlpNc5C6WA1jATfEYuSPM3owCYPdiJ1FJxrFPA329rGf64xW1eMgrW18YZWOresqKvYkg4wk9jt9EQ6+tLUzi9oKiLHb/CI",
 														"3": "rOeX7b6mKw1pLe52wF1kzMz9lrvN/iTiGUenHb2ISLUyEhMxt1o7ZAdiR0LXX9IqGRg8VRykIK6AE391GwqCGtLsW/29zLhpmQf3nmjVqdHlHOffJP+A4ntb+cr0sHAF"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_then_quorum/attester.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_then_quorum/attester.json
@@ -8,9 +8,6 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hcvZ87OS4IvP3TIMf8vyIPvarcFFC9HkMa47sbpCotbkUG6bwZjn5lcf/VQhg3bpBKbBme49JyFEbakhxq0bhQZ0cAQfSkVEFc7uzEHuPwew2dw+pFnm2ce18p3AEgJf"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt",
 														"2": "gMXzIoe/QJBrH+ntuAoJ+kvr4qhj4VUmWphfsoLyOQ2VYjwvIOqDtLlXstFKbKXSCqNmxYecfX8xts3jWxcfHILOEgavz6rA8kiThsqlCSHWx3yDbjuBrISi9kU2a0a4",

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_then_quorum/sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_invalid_then_quorum/sync committee.json
@@ -12,9 +12,6 @@
 														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6",
 														"2": "gfJwcjkKd72XrqH1PyfpL6g2zmLhvX99oMlpNc5C6WA1jATfEYuSPM3owCYPdiJ1FJxrFPA329rGf64xW1eMgrW18YZWOresqKvYkg4wk9jt9EQ6+tLUzi9oKiLHb/CI",
 														"3": "rOeX7b6mKw1pLe52wF1kzMz9lrvN/iTiGUenHb2ISLUyEhMxt1o7ZAdiR0LXX9IqGRg8VRykIK6AE391GwqCGtLsW/29zLhpmQf3nmjVqdHlHOffJP+A4ntb+cr0sHAF"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sm9zOQS/fOSQSFo6RIcxcycGttReqMLK6b96+2qIPaWjypHApJ6ef6S9ynLsAGSDAHT6eJpiQBLAPGnTFyk58ygYxys5ND8FRwbZswjr9I7oWDNX7GnRajWZXy/xVd5d"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_partial_invalid_root_quorum_then_valid_quorum/attester and sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_partial_invalid_root_quorum_then_valid_quorum/attester and sync committee.json
@@ -8,9 +8,6 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hPxPvEgkWzxdxL826zMik4cvoftHnuPt8q75/SvaXubVR+eOmyFn4DcVCWHSpKNlDYlvYe2FiRgMmf1Ix+N/YTFn7h2nxLblcqB/upxvTN/r//SQVcaZEsoIPIYhJ/L0"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "omdKVvZREI7/13r/MEBbZ1qvOBDvcLZmv5wc+8c2+y6dQ0pc8BekK4QY0/3z2ufZB/3acnuYPmgjt9BNA7GSbKiaru09wf98a1Ci7RfKsd15i1OrDfjbHwJyFcJOrGT0",
 														"3": "uQW6KlBVbmO0r13Do/b+5Q0DRwLRUtN8RFVJGNltIK9wnuu/9JJ+yb4gxjlCVEMFGT3s/qMrAjLovxVXml+kPI75ibSbbxnWVc0uiIhCvY5s7a8W6NKz0swFAyhTFuL/",
@@ -20,15 +17,9 @@
 														"2": "pIMnG13JIH+83kIsioA98IgyOVJ9Oq71Klbl2HRRbpWVYJnZVXwtcFF/Z+MtYs8xAJRfKd9n0rw0CoBrp2Ehfumf5chA8JV2WXRenzJWaahihh5vPc67Mc5BYE7GzYEp",
 														"3": "lVzSIUi0hK/w+Vp9cuqjOJpi2CUPN13FxHKwvpA9nHPz3b5y4xCVKGk76jdlQdPODQwI5nv4BjtshO2aDuV83R5vouYMHvgy3sE9ouAX/EnZzqrBFxBU8X1IFh4kfTbQ",
 														"4": "rd3NOwo9LigmvywtW8Wj43oP6C12g1/kkNAByOYdqJkmtvuCmgkxssPm1VoLTNX/FDpWYJoDDPI4v9bw8RS4C0WXExfgb/5/1k+vqNz3Zgt5Q2Kz6H7Im3fA/gEHi0XZ"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "ifxlSDBqXziMuDYrqzxTC2en4AYHVvmMgGsbFUAzf/lHJIYNz673bVY37nD+wYtYBGRRuekESqupUFCRJ96X4Av7H0krpyS6gXHswvLbwBmOWbIuR8shJdCdP5g9usNw"
 												}
 										},
 										"10": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "goaFXTZC9LxayNZOmR7Gg4p0SV3hEDHGB2n1Mt1zT48YzTA9rdTcCqbRBg5ZBkeOB2YnaUFy90HGgI4oUBtWSFPLnPYsHninxjPkrg45GU+2rV/xRzj/z4aW8BQ7B4ZB"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "uFT5oiBIUTZk+hE+qhrhlxM/9fMr506mVIWsJGpfpFkZlzfPd4HPNXFkk3F+H3wWEiKcyAhk8mfXDOqNmeccI7XX2xM2Q6atvAoj1IKvVE5qH1n66CYrvxcCWjE65X96",
 														"3": "lZr9/Z6bvXz817/xtfX2DXRzy6UktUIUjX5t1CV9k89cM5VdODoYeEM809atwfjeE0ozkDGtnlqQ1SaDZQUBNdp+t4TcoI6orplL9zAYQgZSpxldhORFZCEiYtZPlB0Q",
@@ -38,15 +29,9 @@
 														"2": "o6vW4Y0nzGVLpxEk/hRsY7ksjLJcDnZVr237gnIe53Q/Pgt06+yDlf2F8d9vHPkeBck8Q/xKC/tjBiQXXvJwoSEN6MXLnNGgsP3UqDAShVA9CG236n4j0GKJeoMrZa+A",
 														"3": "gYjO2BmHvQzxBPMDl9skWbAh9FDJad3T3ZjwTl8Pi+Pt6CI9dSybaMlKWv/DNu1cAZaMKnACRpjXTwsaX6zJnyztCFgF7gsCEbhj25+omZyaNEjFrLp2JdtePWDvDtbr",
 														"4": "hUB/pJWXi0KjXeaPo4TJNtJShBuGg4vc8gd9tx1zTViQx6hZ2zxj6MQMIjrtsUIiB7HJALk+DwXRRC8NFOrHGZcT098sPNVUX8Mlra5OT26d+ZbNwvhoEjrA7WXg1OFj"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "iHWlxiQVjoSebIs0h60vvxqMTsxvnFNI7SXT/of2iXLeZMtZwWEDHgLZBlB1PaCtFRQtGOyzn0Bp4OwO0XWFeMZ0j3rJrrmPBpOb7eYpySKhv/mBArPcmdDvNGd3TGhM"
 												}
 										},
 										"11": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "rdjQ3AT5WfrEijcy8kMyD/3dNL6EAuAZ/Obcd5smKye/SyMOoVst5vLls4V9Ee9jDHK/9TNYbJWbLSeUJf8SEdLbzjfcwoCwWeznLb47dW87u1rIKfcgLGv6odxJ1VdF"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "i9erMzrBV7o15BeeWfvcCjHXQNMYFzSS0CxliVIkhh0rlYrf0nmwOipXvcuXavBpAj9Twq8GyOxzDMmKcXK/Bkes+8tDt8pEPOBu07ovibYFW5SALizIq5biDzjwTm9D",
 														"3": "h0H4Jwf6wyRBziYbySL1TJvN9gNPdDYoxs5/l6tsaJ0mvRIlAGvduNYHVeNISAsSFKdNlkEIMXxbjJFNBaLc299NKDKAl4Ij3U4vtvuO7/St+eNe8wBJirlLiXUu98lz",
@@ -56,15 +41,9 @@
 														"2": "pnDw00vP9eiVmRUmJGTQ6uavMq2ZorKwSAwOhqyD5lwyYeMlXVMzL93kZcu0iemfCw/x0GYXDRQIUcBvbTFu2frIXSRDuW8N8owaqBGZyOm0exB4bXnfDlyC4kPb+d7+",
 														"3": "osp9nKz5rvwmGrE1pNN3ionMVzI+JkhR81ywWl66peR1oRX3ucZsdgHTqrAuSUGgD3M7+WCFUT2eCD5U2/KVfj/vOv6KgI51EpkOO3KiyIbKfqfaNYwk03dqkzc4R8km",
 														"4": "iMN6G0BejpA5x/KhDvCdpM8fWV5Um4BcVvQgXsLIfo7ypDOguLCWB95zLr1GmFxvFowR7hbQT26WkbwqGLPmrTbyvEarm9QSWgknJW9gEooIRUw0lsb0QpTEx2bKKdTF"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "iqUIcHBKm2iYni4qQ7UmUr9x43dzqLje1sExB/IJleyNY1jr8xz5DJPdXkzo3rDHGOA3CqltcrNvXDBACLOAAj6F8QfK6HRl+8kEKcAiuUUH97diYu70ArbR6FTJjCMA"
 												}
 										},
 										"12": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "t1CV1LsIK1j0nqgdoP+e/47lk+xgjxUcys7UUlP+/zncJT4dtERrzlX99rlRvJ6kCgPEW/XkEZaNYF3mq3RQH4b8PjLvGkJJG6dUxd76o2w5Fq0kpbwD/wuIlZyb0zOH"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "hHCVLGw8+8sqjybUiGSxkOdQ2NqQmiYBY9msTNZni4IEGvo5RhH5rMMHxaPmWrViENEHYFdRHDeE/9R5zzJiDPJG8ApJ69xa9V081BkNa5lrZsAFbluBNN+NWIpB0nhH",
 														"3": "p1Zs5h1zFqG7moqqUqNoYo9AVqLZaB7cy5xgX2BZTNBBwyZVb/OwhwOrnZYwMvXUBB5RpKBHkYen/Y3qqsneR7jIWY2+cdGOv5nsus5+BI7q2O9LnjPpcQw38aZX3TEz",
@@ -74,15 +53,9 @@
 														"2": "gDhZYMUhjdOAdtWI55zlH9fHqF7LvADNGvTiQJFDd0qxVAbXGRQgg6LAEvnWc4qCFVtDZp4l2iaciE+jFsi9kY7Yskkx7RiLPAMpfx3vSU+Wm9iNVA1slAZzsOX1vyLV",
 														"3": "gAdBb3nGJBskNROVkzICvTWbYUs7AAwa3LXoni/l/PYzCOdN/2B78nhVWx0XsNKqDaC3yBbMKsCpTv/KDiYmUWn48KwusgVU84x6gbXSmQd4Po/OTQTfJzq4KzHRGuHF",
 														"4": "sQI464CdV1s2bbYzCJbcIzK8seKt2keOKEmcvpoHU2JGR2dQFkjowv/gv4cUqKOIC67Io22O2KBg3Kx2OlHcHhxsFC6NKobUrhussfrkeqbV7gIEoWHhqRGmcfSWPFyj"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "huT+VfbLb9A842GMK1ypFGzfUTEn9zsRUjKgD7KOGBvDZiETDLazWs5kj5uhLXAHB6LGCRq3BWVmVKy2MFsptkE0wkop6o84DdLBBKEMsFAtBZnOFl1MaJH/Xz1VUkS6"
 												}
 										},
 										"13": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "rnAPozj3weuSiz3Sk5rooxvUU9AXIMbnZxpYeGdR60SavHxYVM/eIoBiMoXTu3kyDt8zOsE0XWLAA7re61xDmGbqBVsMoc7MIGTt23WckyobhR1cWeRMRMqZWYLbSANX"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "sz4rLoe318wR9oyobOzUcY1VXH6h3xUt1b/fF1syqtUt+Tv5/MuqkVtS/cMD7Xh/GGI+QxE3+c0PgiynyEDo0E/9gMChu6VzZxL4hR6LktwMSl7vxdxiaeeywYepuiuC",
 														"3": "l8yxg8e4ohN6sIGwy1qNfxGsupNc0q+PUhRct+fE2pq78HFLZrlg8oMtvGkHIYubEo9uLnOFEiqrIibpOEjwJy8qWJH3UMwS0RPz2hOseubVYLZwDY+WAacuKT+VpPGv",
@@ -92,15 +65,9 @@
 														"2": "i6PpYZQUhQPXMgYL7bITp0en0oIWLso3arWDQUkjxLPr0ViM/dHOexKm6rNQc6HFE+8YyjlVSOhZVUuhLINNkqKhv34i48/gy8JWd6f6Mj4XSC+pMN7CGsAbuNzOTJQC",
 														"3": "qBOKV9mJ+776fcPRgjXd6Oy0DaCNU27nQUg02Ca0OMauUlE1I9dcv1CIGBV9G19ECrsWhvQR5HwPfaAAojWXQTUN2jH4ri8zH85EvM5idoayOn/Uv8k7BtUL9szYhJbO",
 														"4": "sFE0qlgAZvRIL19roEKf+d18BHbR94qKdSVCKsHA3uCjfNfRHXrwPSJensvl24cTECmQF1fj6mmpGww7vkfX9ppij4VmX3K83g/rJIoTIejADiztRgc7RHtcHYtf0xMI"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "tw3MS1yVxbG/MAv3FTynoEFzNhz3qEX9nrtl6bJswy4Wj2ScZ29U3+dgZeKxc1GxEsXO7jG+pk5RLNXSLBa8yd56mcERdBl3mzRS+CuCW5cX0LW2Q5KWbeUjclHMsfyv"
 												}
 										},
 										"14": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "p9SGqtQ4BXcmPO8e0Kj5AMdGbY6G9exrqOmIqakk/m4Yeux4LYgoSqa0lT8dUOmhAWmHAQ9WRDQ02PFOFy/bCRSJK0ScKOMY9anUErNRpmKWrrwOseZYs5YHlrsOnKjh"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "j0mUfExFA6YJTWeMwNighA19dsWNYXqUa0PyUQJmyYG1ZAa5IqSaDGGDVVI8FQbKBF1GWOH8C3rFxtZvfaHdWqbLgqyY5Q6m68p6byooGSAiYMzekOcbdsLcNuMAiux/",
 														"3": "l/I7BT6qF8XcPRtZls3NsXpL60/Axpu8hwnZX3j/vkWKUPSwcKVCoSdYX/xEU18oEXGkgfejM07yTEa4jxJJkoNQbsP5cTjJhBbqvikJcw4v53SNELGcvTaj/z7n01XU",
@@ -110,15 +77,9 @@
 														"2": "tr0Wb3faJGKZ1SBNKi8XKOfkrisuTbxAum/fb5Vl13ymQkX1tfVkUHOhH36AtyWcAzYGF35/jMsqoitG0asU+47su9UylzWCQoLq2toc3E8roHeHJG1Tatie7wHWj4kF",
 														"3": "t+rpivqwWurECT4gmixMfw2sMSQl/WNqykhQ3jdpRBuTa2SxHHAnZ8aWHv83LElfCype5fv24UGGruPfANq5cLsirDm0YAstjk6whgL/jZCuV2V+CnUo2zxyUlY81pUr",
 														"4": "oYg6s6PfYwSi21cjHssJCuvfPc4BabTXaqrswwLCw3SOZkW+JzM7Bn9diUQbtk2DDCWfDcZPkNXCR28QK4GZblRFvTZHCygwVF3jB+eGjUjflmAlEk8hsUS+eZYs3F32"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "kBEUHVAmNyigjutVEDd8oSgrvUqmpmYJdFeWlwrPxQvJMMSqtanGbLRKGeC9gleOEJaZmCoCjoG+ek5QDYppJNcxfHm0pUSUhssUb3OMOhfA56XK6MCVg+r/AZJznQKA"
 												}
 										},
 										"15": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "rFXBCpa5nJWtN/XJ8qZrDsUdOeFtAd3XgV7UlOD8OsUmujhL/I4WnieU6sc3p2AmB5m9nz0tdnX1jzbv3jSjB8qDQPwqOGRVWK6Vt1cNhObIpAv706/FLkcbquCreOe4"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "gBTbwkrVbmENCIZOVkomgFWtf2BN6iGZJy6UCJE/EkZnM8Jw+CvKtIfWyhpLE4KiBiWsv+7ZNVrREdlOtSEor0U9VrTUnblll1oDkVfx4+FxFGnfJaKTlfO/nolh5WHa",
 														"3": "uchxgayGffvLZ6kcsKJbOAkbxaD/6AQ8TMqrRQES7BY5Vjjhx5sVuoPY6P2llQ2hCwBOWTiinuFpo4gHZKpjmIqCP9C0HgXT3wnUnQuxGyZoDZibZLLlM3h1Ib4tbShH",
@@ -128,20 +89,15 @@
 														"2": "oxuNV1fA8xXXHh0oL3ETdXTRCu8+r7Z/pokEZVopT3R3UTdJjJEzFKJzBlPxlW36EKMCQ6IoFq8ic/qKbma8ULVPPkJ2MbscJEUzedUIzdXwOVVMy8oHK1lGju+LwEPn",
 														"3": "s3Zd8osB7Awmg8zhveHOGrSyWUZoZRrApywADHKndVCp9SLWMJnckv/OEJx0fonrASphLthpjoF/IXJ/o83czIRQjjstMgAuCcXcNwVGMA7WLLDIrTxaZe+eEB8jawy8",
 														"4": "sOsi07WW6lutVqmr/XlAWmtUnFASEGGp8MxXT5RWkh8SQaO/NVrwnTGDcANHXU5qDPW+neWkqHvyyU8vTc4spR3GwXltHVVb369lwXY483K1ya/nYTFxmRFoOaGz/5Xl"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "j/F6U7v4oepnoCtadtEpPa+QRieKUMkp32RoC55GF+f2l8oYqH1lfoW0pVNiMxfRDWRJkwAtjVmGhY7T+o71ij+ggeB82BFnUWIOdjv/Q0Ur9B2ARBdcn7w/HtvIlKZD"
 												}
 										},
 										"16": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qrLZg+F8YTdsMlkfH6HkQNLA8plNo2swTbudf9cqG94MHL4oC7lNBf6wh9TVNiQZBt+I59lO1kwHHzccBgd9abnYt56ByMYiyqBohVhK5OXYLtfe3IrnIfrVRHKol2bC",
 														"2": "qn6Xq3OhyegpHgCwI5O0bI0Qvbz+/wX2wmWL+U8ucFq7AgOTtIbHei6yrrPLO2D3ANk6tbGGNaTRvnUx2vkjtCJj4EGnghUo01fh8q+u4op3rykBbSvjv4v2G5tO7wdz",
 														"3": "gjxWlb7sLTZ5fJWUwp0OvpTTE2VQA2E7jX0ZbAQEPPBTJtT0/GBvr1CbUgAkR66qDgywTBCblQAcj2/dEF8gBEzQae+maFOodHmrLANX5mwBj8anLJOWf9ykMRKBWH0J",
 														"4": "gYJ25sa3GOyH2vsB/XnY8TpNQQ7DwKtY7lSJ7W3hKG5PgtR4y1VLcxbcHTxpJAIVB+sVikQVyf0gk7YhsD3rrPLKwZp7iimaEASdBvUvLzDVOlmbG1r8z+ShUe5Yk7Xj"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "qHUIlfC6l05XfCOFDm2pJIfZh6Wqc4O9OVGkaJYg4A1OFRYD4ZeEd8SitIVViKCoCVPBohU4hg7lmR38ivimmEfeaQ3ytpR62u5x34mInrDyCxi/cZrHxBl3/DgDZ+fX",
 														"2": "tQaR+u9FMoFlPznyVwh+seNc8M+W10pGeNp5CEN9th08QW+WINQ1mCf4ERAkJH5NAGsJPupObA0DsEQEPV6jZaCHIIGL6gaqIdXVCusOlzfcCbHx/wM3bkAJbF4pYHHG",
 														"3": "le4jr0bf1bJqtH+osJDH8vTBbSoVqNfersk6rDNNOIAEAu0LUesc4KHFUYpCY8VUDAE00KnwYogoa3jHLboB2v12krpOQ4M4/E/eobyhSfyGzvyGR7+mtx8RDUeQAS95",
 														"4": "t6Pcqx85zA+VasZhbSp7Sh/m1vGvkpSOtZZQBSVpC3/YoboTIhAmqSb6ic0t4bn7EyCPcDPJ/uYNdvBOYpxyspFr371CsyDXEHwij8KGXd8+PjQf335WodQCP2y2aj6d"
@@ -149,13 +105,11 @@
 										},
 										"17": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "rDYmDfb/MA7Td46qFq6aTiYowqMNCAC0yp3iZSglYyGULb/cU/RhJriLZ1ohJ+zlERyfeTCPq+IgTrtSZm/gnqJ7fz5+PhXeZGfBx1ykd57NIRZcmc8BGq/9/yXwt1Of",
 														"2": "oSxp4+0P5dXvHwVnIzyINy3/T7S99VDBwgcvi9TyNRuFg6OSzqvYxF6wXwkla4jMBtrar9s7b2WM5s9oFk+lUUzdvZoAbGXuI2DJG1ZNQw+QxJEIBeWCHdu7hp8+kFt3",
 														"3": "imz6LUIqEO25R0sXTSqTq2qKiONMqtDKc63CaRDhO5bQ/NRxk4GZv8Du3r9cm4VRFQfp9eKkCjozZJkMwKRIVPoBQ0jMQiaYNRYDwcq2nyfTayVPZHtxKlfjo0CiHvFG",
 														"4": "qqkQFPNcRCDAN0lzG3H0J6msU7/HeGuWDy6YpMdfm7Amij5WuLuJnZw2Br5liEpKF3vm/5NPpesrWMEQyyggSgqYgT3/2xo3aI1G4VAhCdiS6Sv1zvKZKJ1bvmjgB3qS"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "sB+s1BWGt2T5NJpihTu6DJxvBOT4p+pmRir3Wd0DR0NwSZCDif+CMmZ+MvWeWF+0FRIZs9sOWZVKIOsQNmG24UaAK1TEHZ51reGMK2a6sHFNPMvEdVn5/2/4XzIA1/Gi",
 														"2": "tuxc2xjhHahIqo/vv3bvTGJkl+dGWQXHPjpILXKxdYbnZLB50YQ8h102Vxi6w5/+CUnUmr/Fi0gHYOW0gJ/dOguimvwzGEEZiYJkXP5b7W7zGqBP46iZ9JhCm9V8p42S",
 														"3": "pVGQSFE9EV0GU8IuviMRnwDoS/0Luyx3XpOZffyn3yXm825e2hno3J1N6BJisaEjFfuD4Ud4ID1Eg7u790vtvDVyV2peItT4OfXj2Ja01VdAmzdzcsPom3YoomcVrxPK",
 														"4": "tTi1HpEFuNaYGGOVWuA3E7V/lHskuPg3kTeEXxgCDtgEXWtgp5KEPyTG2aMkuP+KE1krMISLhf+ffrC/QMWgEEkPHURVsSgtx5k7AZNICEic8Cf4cnRi5q8O1AA4qNg7"
@@ -163,13 +117,11 @@
 										},
 										"18": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qfYO1PZnOdyn56KlUf5UuWa4T/udPhGQa5VzswkWlCLvHifs1UaID0Jhgs+tInD/C0Tczf2Ay0w4vDqeJ2anSDzdzDQcm2dZfyfCjuKSoydsUSPshEguUTmUjBvrsYMh",
 														"2": "o/xcYlHccz1LY4QknL3Tm4Eh7ypexKW1s0Z2WZguRhtZkTyo2gOuSPZ4PZAnRhdXCmmCu+zyt1IcdQ0sJzBnpg7kbukuDXnR1edSVZE+E4wEQTd4zY8CgBhw2OHolQkd",
 														"3": "rhi52z9Lner9yKFOeJhSFREE1Co4zcwII6ammqHuMdZsAuYya02PROT5Y8iQH05sA3UVygtvPe71qP3ZvDX8u6N5g2R9IYPgTO/bokfHgWelqz9LXfGVjt3fLvKiKhvo",
 														"4": "hEj0JIGRdv7CNON3vYATgwobiYa+LS5CvVRtc93Br/BNRgWnmGCvee2kB07nR0rUFeSH08IpXmyBRpqvngSMH5eHG9Yc+NMgw2phnwLj+qFyjnCwNJDtuvnL9R24Q+Ux"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "pMB0m9YOSkmcqF3QeK1hYYSnSIIyGBLBCggHyNAk7VXyvQrNCfrJP5361fnBHSJgBUN6A3s4QMq0KSEbSDcrtZ+rR1+mIFYGzKAxZS+Up36kDfRlyA5JUq4uib5YZPz/",
 														"2": "mD666+Lqq2Bhjt87aNouTJS15+Ppz3K9OFYaUuKnBJOeig+y3aOp0D3YozEdi5gzC8hEFRkwuse+2qF/4fBLXJcZQfjXdTnY45WKn2pSBTF7Gtx/k0dKueD//Y2Y3zxE",
 														"3": "mDs4lUs05oiEcHnqbb2SjrsaNKnNPfO4sfjcomtuMlq3nT7I2GpkFql7AJeMgBOXDuU5InOwxrU+qrif7IRqKfhQCVC57Kz7Gu6+aFp6LspQ0NkdsiGhk1VZyBLA8h7t",
 														"4": "l5G/JhU7gSuX6n1ZY/Y/PzS5K8rZ7ea3IStw8RjxP4h5BUlpWacK+YIHqTb0NTHsEaF+txpHRV67SxdhiL2KZ0xfkBCbquojDqyNL6+BJZ5jfpRH0zp+pjVvL452buHZ"
@@ -177,22 +129,17 @@
 										},
 										"19": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "sQ/J4kLWhiaZ08IPAr4F/Qwf0jtSFF4PZq+FTwdoyjw0Awv6ez5379hzsxAzOsXjDDfNFYA705hNdAx2pgbkGqI5OFMAoXzE+RNPG/Q1O2GEoQgU84lqXIH/rVSRTR2F",
 														"2": "gvHoto1Sl91Lrm22L/jtks3/DjVGoaQJu/2zKIdTprIQqeCBfSAF5/lf94hWNljQDEJ9JCpB9U7CRA0yb3NK4WB6LLoOE3YcjR094eeKJjPTxUKpZMENdz1tlUksATJR",
 														"3": "lxsam3hbJlgYZtncajLN7DfgM7CKDxusZLahyRtvHg0vGeENUagtTbnjubLNnWWbCrxCkaA9dcCldLDuU7MKvzKQ0gZFXTREe7eMlLPy2b2IFTFCg802E1NTVHuCXVfB",
 														"4": "obkn9oAb2C4VGSkSDPdywNt9nrmmnYvG7+H2bWNPKS4OupPhQQOKIevnHGI/PBUNA2DSfvVYfcGUzj5AISurZyglV7fm1M9cdlfd3ulzZcjif8s5jDUkhe2u5xL8mdTg"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "lcqfl55x2+hOaXxOSfb+ebKGv5m6vqnYKFeEq6DFQoA6En83nWZpYExJbDHGB+J0FtPv9EUpKDhRrHZkYvvVQKT+QIcjgzihryPw+syrP17UPuatb3p+z+vEtdZ1dQUK",
 														"2": "tqu0aONhB5Vbjc2yeF9UyL8BJfmw0chLVP0UcDnBVM9MUCpm5PWW4sYCpLbjPdOJA3UJyTDoOvnL2Apgb3V6u5IlcUpnknErqPc+hfPF+oUytGixB3zCbiFg59j2ONNf",
 														"3": "qgPawbAbxxxFeiRuzZR2yAscpzVGev4ns7+PsUf49vmWdK4W2m2EqYXzkp5p0Lp+A9kJLPHBPxu7esxnys0776/YddwNcR3LQxvbj5MQbEo1lSe+j07qFl8Fs0OD6lyt",
 														"4": "tfxC6YfOIx6wNVoYxtg1caakIs8cjTbaWsOQla2GokauBCPRzlTne3gmbgFffb8hCXqgTQNCO+mtXB5O1WREg1gGcMoX/fgwvEWLLGYNZV+uTENYQe5vcdLuTD5gcvO9"
 												}
 										},
 										"2": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "kSssanFwQeiweIayePbTZm8t215xD4x6Qml6BmeA3Lol1YDy+CmdTd3WE9vZd6V1EJl3Qgm8+z6RO1+Udb1a739gQ2bGbkaLDZ53nM8Y3hITrOkeGHPYY8YdJZ4a1DA1"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "rfSh5SGDXGU4+wUZTg1uUUFYXvEykDWGNFTO6xOwfrLh9SRX1bX58svbgMB1iY2LC55FnftDnzNUpyhP1iT74vlOFV2ucgtJmmzi6w8LfoeLAFDNH9qmgMIz4qUyxKsX",
 														"3": "uNUbp+nJxYnHio6dpjWNwpNggxCPPSZ/wnTjKl+c63Tq7a5FArduxzaCSzf6bPKLCGNiToapuhCVDK/PA4Ty+PrbfWM3raqpja7ztXOsnwrR2siA58lL7G3okiFgy+oe",
@@ -202,20 +149,15 @@
 														"2": "sse4OpX2djZmfWFNXErtS4kUM6mTQRifa2iHnylR/Me/dH52TrUqD3fZK2XZjG5UEGCLBK/yJHLd5xl3LvW1QiCfH+ZZNxa+um6YlR4FKzqTjGUBwYuZKzfY4Erm2KW6",
 														"3": "kFN0zv6kk0yC2eqgtNEQxBi/CgO4wa0oPTIMJU9CrOIzgaBBrUyl9/rDkMQv0FZaCFJhqQQZB/mvvWmuoQP6V4uYGYr0MyQ+rdfLX5KaNuy1HrGdm40HKwvdwjKiFR1Q",
 														"4": "jX9ROhVvkkOZWGTpv+DI8JpLMt9InhdV83m38KnclHe+hEob+dlDsDY5wTB7ahknCPlMnQPudGj5W7XGza9PKE2Q9Yd0jtDTwxHe3Z14fLykdxSeixxhpo6ptzA9JaXN"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "q4PqL74+WjcReYv7KD8iBy+y01H1tNp/M4TrVeGwvADLmADJnINrrfoBX/xyw015BsA4ZtV3PKgpXlgPll4WOSA9OeK7UHO7a/831bih3cC6uN3QKt7TmAodx/Z9YvMP"
 												}
 										},
 										"20": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qUELJnr1KxUV916E46+hyGCSLLbK02w2OmIOP8ex5Pjz2c8UG02CNwSv9O8/PfjtFYvEGd1NGqpvRtrLLFAaYWHMs22zuIIGHWtG5j+HZEj20LtArqRA+MSC+EE6qlFS",
 														"2": "h0oqbOoUtfLAWnIBb22Kr6ROIsj2s6diqumtxAw8We8qyX8TIrQ72DYCqhNz4PXWB/JoOmabJCzwXqWLt9Sp863engVBFv67iihOTDm4E6UCDpTk/CTz4GCQOgVVEHGE",
 														"3": "g9XNNJFiyCfZmDiZ6APWSaqb5nQcOmVBJFZWqVyuwj8aMqySmBVhleJJnRfqGEG2Dwyt5h9rV+aRLB45rdVD6lQM3x+kCbqnM1QwxVdHnRP8kBVkvcy/AaOhjfnY9Elf",
 														"4": "t70fysV7wB2FgSeoUEspWavbtSf6tNYrMisp7c9/FhPdmkDeWKfVUB+mykxzxZBqCEcW975PxO0mIqe+k4igsdB8UtSmPWyuj4lu0yuCRzjV3BYEdSn8tzUP5+sOmEzs"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "oImuJxsGrLnkqiGF1uizyqWpBlUzG3GmNjskWTt/2m0W4EIv1R1pUIXv5YFvyXCUAm3uHv2HkMgrkpRCkcqcfuPAZCHDgUzDLI1U6kM5eDy9kAHxcCq09edwcGXxGCO3",
 														"2": "iugEU0w32LGcpYBVpNvvGMeZqt9T6Ttx+IzPsDqeYZdE2KYDNzRoqVacrbNVbAwACwZGgIB07LrqiuyHKMiLNo/PdjXuqrl7pD/Ma+2zN928AYwHMy1l60XptVFQB4uR",
 														"3": "iqn5rxAr2q4hrhMLjv1a99Mhm44MaFRv/AbAjGSK8sfLX3ElKeeOGD5BFo04aFzvGbugxH3qkbp283sToSuAHjEG4FTXDraphwACHkP95Tcqsus5q3a8Bte550g30pHx",
 														"4": "ufo9wODSlJeQS/71GC0IKNfDBi1LVMnTo/h3Pul6Bd9GniAxx3O4v2NqQVtF0sdgEyV1pq9J++R+MCacIrrm7OQQKqHMaXMozV60yQvvSzYn1qbQ1zNYahU6qcHMzUOI"
@@ -223,13 +165,11 @@
 										},
 										"21": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "tV0jeFgwmLoHp7iA73rjKzCBc4sgoONLTGk+dOdcais/g49G2IS9No5aNlG5S2xYEfbBr40CROeiOjGS0yovTsgnWqb/lcABzqy9Nm3k1pURlHoW5/QfTwpUnfNI7Da8",
 														"2": "ljl8Rh8wo7OoB5P4C6FIuBO/45viKVU29/qUWVbAr2xy0v4CTIlrFnwxsR2qSr4GFeRWT5KHERF+Ob0nmUrc2uvoSM+EfQA0iBbfA3z89vG/fsrpIPxlMC+53NB9Rdtx",
 														"3": "ipsiz9YXU/XkvYzNB7yyd1g9Ahr82tW1wFGqzBZYoyPb7cbpxMbwWDf8p/Ixg8dNFuyVDuX14kNe0XRa/4rUQYRACxZ8WK1WKtYonHblhgMYUJznELfmbHqTTiSPfj1h",
 														"4": "thh+Ng08PXB+0Rl+Yff+RUcqoGimkPQsXUVNkF3HtkjrUj9ZlOJDp+UHGXLxyXWPBy1X3e2cTNBinZDPXVa4wL+QKL15C4y5CurJelQ2z1oZsS5zhO6789DMeZfLuQaY"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "gup8i8KXwNtEB43spKOFQOZq3bmkcZtPvjiUUOTX0SZLOO9bddaRscqeondMGjYMFyMvptyp+gjS/NMk9L2LpQZGPtfQ8fBZPNPjtf/EP/prI8UIT8yPeRE2jlTMTYtm",
 														"2": "tTGKCqRa6QNqubTY8qVSXSVX5q7JvRNgV9Z/O1Om/UqnVaeFo/WndMssRJ1BWuwQAtYn4k0L1uHpo6mGMy2AQ9riXdSQ16alQTufXxBVQoWj7OyfBh0MfBma0yhVzT2g",
 														"3": "qoyCP/FhEWGJvVRff7U9K+Mh/wqQl0t8Yx3MoW60KwJ5Ew6Q3vlXwrSmCWclOsESGPTqC6CGepRTu2brDcn0GT7UBofELYY0KgYgzIt31/rzuPCfSBExgMZ60OCdDdhm",
 														"4": "tEj8FKZ+UDKZTjvA6fBJUjdO/NrjdUvvbgLbs8Ftu8ZhxBBrnloePLWEBE/R8k3wC3u7av4oXep8nTdFISj0gV+IB7DMAIbnawAQilKgjGAgdbTuroV+yao7Vpm9wmWr"
@@ -237,13 +177,11 @@
 										},
 										"22": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "prVC0BIIAclwtPSi3tdiL7VkuVq7PLh/xQYHEBTb3tOSDbLSFK2UpVIUQm5T7BrqF2FMyvn8PzAK5mksVZzSybnHCgfWaxmodl2beuB3YJ6fS9jCNrPDxMS+lszAoEx5",
 														"2": "oNszWGYnHYFqflF46LrpIg9rByZv4zTVxaDjwNAvhFACSzd+9Q8o5NKUBn8awl4FBeuzg4yyBhbQbu+UkUvzPE/q4LKqIXe2F3Ok9X7SgbxYoSP8s2G/nbLFLV8IHDDn",
 														"3": "lWsOcnc05uj8tGLazN+GSe/yYFo51DpTXSHMxWNnwUoN0E6JAdNccJPZtufs0BuaAIOpikPuhyw8baDASvayDQOBnRFPV9cdQhrdwBuTVTs8CDsOUem2zHd9o3CyoEnT",
 														"4": "sWIgSY6Nt3kK52pTkruYmRS8QBtmJgbSyYPHH32W7/BspwOrU85ajQy8W2r9ON9EDN3vuwKCvM7T0eAuo2iGA8/Ky/AZRoKyR4LJ9Do+e1pWreeNkTr8pHRDv3gdw0k6"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "pRMLVTei4ygVmeTX76sj+1gJsT+xNxSXdGpY9Bv+KdjEuMUnf0DG6SbXgb6o2eriBuCRik7X1a8zEw36VBL1R2jxUkjTdc6Naamlmw85c9FI653CYbWLHfOrdgCvWiXA",
 														"2": "iSheE12bCf7C8/L5aM1BgsFEe+ksJIuyqMXtg8nYMW1FFw6YHix7JTR93WO8QB0gAhcMpnOF9jGdQB3yCdqkybYd48Re0wBJB1rLT9H+dVwNeIfIshVKnJE/RvCsHK5N",
 														"3": "g1oe2VYKIcXGn5TS1AMungRR2CNP2tglkqUnJrkup2f0aDtNQ2FoMPTZH2xt5Y01E/oV2XGXg3uK9kDC3Ru05pwJMVqNnSOisAgC+SwiiWqWjk24uyBaYcObhSbNS6pL",
 														"4": "k9M5RqX7n/Akgalqmc1RXCOFLHNrLk9jxflghrvuHXZvzrVfo/SASHXWIoGiKxoPFGY24OG5REN5uncYkmyOGb0v2ktX454tlq8+/cksqZzNzpkDgMRVPl8ZHdDL9ZMY"
@@ -251,13 +189,11 @@
 										},
 										"23": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "jcaYz5lAMroNTkHoRjpu+JxQtxEQEsXi3TvXwNZHM03vu6W3SWGy72lwngV+dklqBLHj+zygF+7mzjarnU4X6LuNTsNNBiT9YZXcAiHBykh2O+NGC+VbyJagE0RSJbBU",
 														"2": "ucBgoM+v//i+5+Mp8AZVnF1dZHJ4sFY8ZvtftEGlEvThPCHKSAw5z9rdJdMjRKXjFw/Uiyw0fx3CcOh/9RP9rvjN+vJIvSGt2z/+Vm4m3UqpGrco5Li4DsVV5iTDgKgL",
 														"3": "qDVaTIfjZvog42kIm1ANNoRDOxJODIpvQ5iSwGK41g4OrmiCQJJ8zS982UNzIqaBC6xj5RlYdifkWhn5DEioXJJEFlg9HdAcQyv3D7oLHtBtNxqrWNdM5THACwTiyndG",
 														"4": "p6crK8wfZ7IQt86yrHpeJgyVYe0YJ22xVI748RFbOYMKGuMVvpUkS9Ak2KxwoAEwBj4KbuS0KKWBiE4elmZ72raX9zpdv7eJkiXVjcHz1kvs4fVLv6mAbz7m646Lk+4a"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "iebsuS4FbhvS9e/H3TotfX0RYQIZdkpXFhLdnKS0bT3yevysHwa+gwZ0Q+rjS8cKBe5TfMRHzXWkqYOyJXJf34YL1C2PV3ytgVV+BGGdESOGfaAVN6DFKcsMYId1lkDO",
 														"2": "ue+mRzAEBiBnquJLeQRIuGgB/Le5WExQ61mMRksxFDcSjr82ts764Vg2DyfPdPJZFqYRDZ9nPi04OGZ15qkLiTogtoqyX0UkIJmF5/mT3E5bBiUOZUupt6OUajGeuq7n",
 														"3": "sqfHny/Liy8AMgHJzRl/dmzosavw2Hr+wY4o8AzaJOeExLMOoZdGU8tEC0Yt8mzjDaTTThRgBP75WLpfxGW1+OCd98jVaGcm56mrWcYTZKQ1xTzwv5CxuJ3sTf2/4+V0",
 														"4": "rGR0DKbUjd5QA+rmPETrkpyFRvMV9LmPhy/H5YghzQk73/tc0xWP2YiaiCYW1kj0FEVhduxEi51zyMf5v+M36ejrksLXJSWX/0JazFEcA/9DaZPFIGFtzgYZTbrbTEbQ"
@@ -265,13 +201,11 @@
 										},
 										"24": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "rjHSe7uHZhyYPv94E55ITjsr20Ni+VW62P14u554hUsuGn8dI6fzb/HkuMfAeEllEwTMUw/t6ri76Wy4wMu2pag79UtXbbvwUMsWZ1KTOWpXms+gS7cDK0Jz02F5z5Ov",
 														"2": "sUAbdrFua4IM56sJQrMt5qmA5Rrf35yiQICg9gmKCnOuat9MkYqgroh8bM0q6VsaArbddrSA4tHW7VkBT+7P/SvyD6ovP+oPem726ssKRz/tN/IqAn0RlK4jvx+gJqcf",
 														"3": "rcQTjq0d7mZTx/+AhphQtUbFdTDHC8EUT9JHjTE60DhdFFX9oK70sD/lGpTIrj5hDapR1qCAzsCZ4IZ/K3SVKxedaKxtz2wEHpOUJ4c8IlsGaVhiCCgJBrDlTn8l6t0l",
 														"4": "mOFtm9U+Gk8soblK3wM+cS0SbfErv5oBcl8ygRRraxyE83GfF+o+E4oLZ3fMLFwaDLd3fNnVgCvlkijSsyXwH7ND3bXt2VHXnB2ZDgPhV6GBheyYN1u5hgqPrbT7jG7P"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "sxo9cfXmi+PTkdUbVN54m3XubuuGpe09ts0Qb3PquEYJ8/2VOwNlDq9oetTTga/dE4uTmUlNPEDa8FbkaRX8kqnFr2UmRZCktQRmbWgi5i85tYV4HMTDY9CvKtIR/oaD",
 														"2": "g3ki4t6hU1yLiYr1x0xbWJLk1M5pUvBDwoGXcFvi7McrLa3i5RcWbhWwlUYlWb66Fqj1vduz8TUoHQDlOyN8ZxJ63lXFUAdOW06n0A22o8y6k3wfS6tYQEUpMUFn+c7o",
 														"3": "o6Td/NAVo3NNeEe7v2TfTNeVaPajINunlkY9Ov4r/FAEr0xucopQUF44dSsDigq3AWPcB+eb0apA0C5NlYtcf7GLCqNjDRGGx6aYpoOGi/mHKtdvkdRjeFtIIvQJeHuR",
 														"4": "pGlEKfyZXE8ciCdKCUuzHmNCAegGCX2Tyb5hejLWgYCY9uvSBpxalAGYfjl55VpqETecHX3xCaPsGEgL5W20V1R71kpWl9z9QF7i8HAxG1QjKCqfdFbUn4OVDMCR/RWe"
@@ -279,13 +213,11 @@
 										},
 										"25": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qcSAock9TBLMFdhicYg6xbaFgwkk9mdj3AktJZy8+vD0FBl0Cw1NkkGLwSX1kszCDTNjVy8hLka/oUkNkI6IzBM9ypwLeDQjzL+61K508QTbbNvV4EOmQlcp229vp4AW",
 														"2": "mIekuezgwsxdPPd64DhExZCw8BEkzmthyakhVrcYoMMCjIvsUgii9KKTj17oQARxCPb6VZ+rg/xblh+DfZbRuxnOR8x5tV7zlDnuZdDkBIvW5/Uzn/c/gkbcfMjzRMs6",
 														"3": "mUCu+YZDE9RFeoCtfsaeztunlpsaZ8ofWqhCd2ehy3WMsyAA5ybXHa+5YxLahlP/FT4FjJ6LtH0gYi+IGAm02dly9O+JSYFgn9YyIQ/lR0RPoKwHeEagpB5J4/GvFbPC",
 														"4": "i4HKJWvWDlJqU9sEiDuiLRSdCxBhmQUE1G6XgbTkvqjwzWHIfp8Xomj5MjRBMNDFFCuTnCtRJjzWjvRP8s3rHC6kys+XUfiogpsRhGsS/iYy06QAmo6hVFeB7j7iITTq"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "hcJwWj6N76HC1Uo4ba2RjLXFLRtlZ5Fu5UAhMeExkJw4C+DNl1RUTkOTgSdw06CdB7WmFeW7MORWVG4lvCnJ6b6vx5o2zb0aInXSIt/PnAtbvyDfEmCYfcKEkgAsDdwN",
 														"2": "uIePjmjpUifSH3jf8ay7pvlsYzNjnsIxptMgtN+ERmdz7MLHxZ/HrSDURLxu8jUDBojyNY091cRvMV1P4pKwXepUUVozOEdKHUi0xW3TqRIhCJh2xylfK87254ARBwfb",
 														"3": "k7Nt78Kf78XT1ct8/Hcy5BLC0VKMjgniuZ3vI72i2ER9Aap6nQaLMGI1Aeyb7domEoKle7z5GGnQpKeEJiSMVUsPTMVqTzhVF35GsJX68+pCJtLLudem3d05vEDaA28f",
 														"4": "hSbS+b04J8DXUymBhwefE4TpomwzlK0p7Szh/iaFj5XLaWcVuKopVFc7tBFhYw4XAHxrv+xtYGvdIRHuMK8bOPMZYS+4tlSIysgGsJTJGHzng1cb8oySG4UtfSLskT7z"
@@ -293,13 +225,11 @@
 										},
 										"26": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "hSkoW/2cKCuKZ2DmyQNdSeofdnayemj2h1/0FdxvkNQBCUujyV3RRT7cooETaP39EhVg803ZxrXwgrzl9Sn/Bfh2t6Qj4kEFNgKgaenLkoe0wK4BguPr2PGx+bovaV4k",
 														"2": "oYm1gQdOYnbj8vQ9pxRWxPRx32B5SzZk+WROAJ/KHFTln2isY6fY2Uag02bzmFSjFdt5AroJjxl9sDikKPwZr/xEjHpY56nVC51lH8dsafV8UR/qDIl3DHIyWIKZdFmM",
 														"3": "k0kt0+fNeNrsgxunbjBh5C7ugF5rZYHED+EvDPM2qXfkJONFlJl+829MlxrUT3aRF6yRIkbZp9NH+uNqbvkiZqBKZ+NfUTrbjZrBp3xVx/bPM5J46ZAoxs/NoqSFaOQr",
 														"4": "klP5UpcOPNPh2FxQ32rdF1IGt3omtppZurWw2OCumLnj3w68LYyz/gdpes82/E7QAxiTKq71BR/Q0qPGyOSee/n2wxXu2AUmtJqxC75dVdX0fiuUCdsGiEBP3YXFIKfv"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "p9jcs3kG8XR/v3bI9qAnejnpAF+zPv+Qgh4TXfraBYj/0ygWR/GTKqqf2pdSVaPMBghbDPl5ogV9gcR3e4BYk6QM5GRCdHXkq7ZEEwmUEnq5Wl7Gj+K1ngqVZ6X6vY/I",
 														"2": "grIxwzjvmbUs9Bb+b6fPmBWCgjDwD+b2ijTqn5xmsosveyGL/IQ1C3tTjXhVUx0JA9zp6cuYBaxCZM1z2dU3gXUjUrHrv6RsEQrja21A+lsXAfv0vegpZXkyKjQ0a3sI",
 														"3": "sV0wYhS5EVcmYSdnEn/io5tgSiswY9HjkUKkYBzT4MJqhZGxy6Q6o8fuj0fqr6vsFa/ZT/N0pPbrNGi99axDfom2Wdxo4CSwMs0y6ymIT1CEO+zQeBdwE5+rtO3jvg/2",
 														"4": "jSRpz1NkVnW/1i+0PYU/kUrz61IvfcCqIdQ6pKqgkHetZ1ADMuP5JDLRUT0Ck4n6At0/gcVuuQ3UlPC23M51ppIMkpQlBQgEdDlk32E+akTSec9c/KAmBtxZ6TiWk7kM"
@@ -307,13 +237,11 @@
 										},
 										"27": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qqOz4CV3KEm9FnJww5SPaJbbYRB03xXsFpIWOs4Cn1evdXLSNkuAS+F0VNJ4ZPq7DHUQ3Ztmmmwot2h9uxvBdCBpJ7D17w3N5A9x92M/OQRQNY7T/R/3w+C1N5tRpfTw",
 														"2": "kOpk7vlBYf0P6w0Nnjqo2E9LOKKbzUMyWk359kCZHBprB+dT0Pgj4w7sQ0vEJG6oBGR5SZbaOcofX9VEAB42COxsVRj9LG5LnNTMRm/TjYPNi8Y9LCcvZ+QxVQBENJhz",
 														"3": "kF+mZJM0Gr3DVTw9kf4xysNhIm0Wfrw0MJOE0QwVwQFmmT+jH5mKoPIoOii4KM1iBTDR1peq5DgdOucSjTj1idb1MV1/vyPzHR9SSHLDH0ziSYMNMreHwx69lon6Q/lH",
 														"4": "sKRNnqO8yhynmDUAbkX+tC7QoAkn8OxaajA1/2ZgGY8tpcdICpwTqyviW7zxyJpoE2QSXMQXWUUGweZEvB0woqDL3/qd4aOchiQRlJ/3iEN/cjLVFneiZsS4Hq4YAXPl"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "mVO6ubOOg/2UZjO4mLkWEyA6sMMvzE1p4mC0mxx3ikgXYCG52tp7mO3dQsX9EcYQGeVCj+kS77TJ55g2CAhcoqN6obMmvxq/PuSZ8eMI7iZ2ZhdgC89dx/jGoZuh+Tbu",
 														"2": "qYfpHfR3l0mn1LllJHfANPObxHV+aJKmVwZEC3WjN43pA+CmTtkdmuiLfIFlCdf9FK+9cwaHJmip9QLeoTdTHD69H7lh0670G6CheknT1ljsNc4OD3yTeeQIayC6WQhj",
 														"3": "iCRSPDfrz5D7SQJOG76oyEnXmEZRdZR+peCVJBrF30xhMQ0BGA1NibyKXG019bn6DkcLheEbBKW0+J7jIYksPjLnLuhBKVV/xuooTEukXQ55EWzDu0EOpMjGh09Inxsq",
 														"4": "guR17UkMl8LNyzoRP6i6j7CfrkG3P3++2S2BryhMjJHZBb6Xw84wQHnxVl4POdl/DsdfOjz+fXSYn4t2Jzv/JEqLMp6urYoJ1uuqRxk+7a4nVWwyYKOqREGsOc2KDnAL"
@@ -321,13 +249,11 @@
 										},
 										"28": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "hvYv0KSXYPVpr84wSAVAS9LXBF6RMan1PeePF4WFRGlFwwOYlXZlg4cysTrxeWAYAfIh49mZN9I4DkR1QiNqJdEqHjI34h5ScWl/TNWdV4snevbKgySnle+X16U2u5uc",
 														"2": "tKYTWsAxcESRXu+g5kq/gcPBvEvnZcbvFGH2vPxYr3/Iv8XiMVOTwMZUXjvxTzeeAq2Y0hUlHXmUW54nFUvNgfmwskjACnduq1PZPYJhAgW43THW8RdjQVAUU86UjKjo",
 														"3": "g8Zc59aDLWLvusqJofw7G+8SrmjhBhP9pH1LRK4jl9e52bo62hGc7P42F2LNMDETAod6K/TVydOa1FPdaQ1q+aH80FnUHTa7b2SA2k66rriKKVm+CeMMYt0axLnMkgHN",
 														"4": "uaEBuC9Xr8lhTaMIawscBN5C3AJ0Gh4xC/dYbAfwOf6aeSR1fTJ3w5LJG9az+cvfB10okm/Z8h74INhnGh1H5ri61XSmAMToA5w/6+mnMm2kxtI5dSh50dluTQZVbml6"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "sQtHz8RaOS83+AfZxKWLLSDg4S9kXDSWhXv8W7oX90Sms9659z6VEBrS05akYvtnAIaj0NlXBXtFgH3EeY12+V+ZAspVi/jPsHzpN1UuDYCRSAXuw5irxlZYAkCJB0/H",
 														"2": "gml/xGxpWAnASU1skjp3HqFzRh8zfiYTll/roOKV5KttrqGWECx3gSAlZ/kvqlVBBTavUtPqTCfyLMQSASgboAhIjks8YTKdcaW8EqpdJz62qXmET0g7f3VbacX6qnUc",
 														"3": "uTxNacsy6/nmckH6o6oqhan5+pRzfD7S0koAzHJNp4mr2BSlmy/Wfs0ZBiR42tpEFPMezVj7A4C2bqcf/8L2TN4JoumGGj5HTNKbrhN0R5HeHqBjgYaoG/ErqhrlGnl5",
 														"4": "hfmlIFAg2rQRg2a9V9hcDRy5dsID6IX/OF6t9+g8SwSK7zE/yu+dx/7zPsvT0dpGDBWq9X20vgqshklybO0L8iEDfVl1F5sJGZckqb7tDuI4t658fqr5deFO2sE2wGpa"
@@ -335,22 +261,17 @@
 										},
 										"29": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "tHbasXyE/fsgcrM6VAR9T6vSZTPh+kCfLnNzwdNSvQ+P5XRDbN0muYqPQvYHtyBbDtA5ertEbkPHoxo9sZVm5ZSm+BmWKZPm7AAgrLiwod/XWBuyXh/tXs75j30Q3X01",
 														"2": "udGw+OBRqRqPrVWyKwbg50613UYGfFkPk9LPhmj0Vs0xpR7dWVKCjfN13KUMxz7gDWq2YO0kslD6tAEtzaJ7Vglq6Y0cE1mDylRFdYF5ErUV21voqIbIhEUepbOyJK0c",
 														"3": "l+7PGQli5R5kOTX5GGzTsI6ht5Xxv5Jizg4rUAO5aajxDDVLxaw+w4y7yElQteLzBHdz4cN/773dpZtf7tqXNqa8sf3maYN91O7ewWnCIuMdm+wY+Nk2DNPlNBIliLql",
 														"4": "lems3rs6CwuSMMG3R8LJOUNcSiNGxzbst+vMyI5SMGNk6dnODPbPVLKKnljNkilEEYONiNvvC7Y4Z2gP7llSzGQup7ilWqKA+uhU9xmdENY5QXbwJWPRmIhEDSOseCyz"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "tPBE6+mCW5QKfdB5claeCj4DQ8pEM7ShPBKupfuMJC27sjTRzplISKNlkQS2AQ7cBPDt4cc9eCuyQZaO80Ok0hsVYyWlEH60IBU0RJ/yMYn781rt8qylFdpSHB8n+Bjl",
 														"2": "rv+uGWnHZJXrHC5UZta4q8DQhrdufxsufd+QDkOjxap93de3+Yys05UHQuzoO10uEA8xnDq47uJwuIQJ20ayzIUUIGeWrKRVGaqw3/x+bu9EH5dKR1cqLubJ3IAHKtLM",
 														"3": "lYH7ogo+W1BmnUBhDmWiHXWLD61SdYskCO3/GGzUUs6hBiy3ltcB4lAHxSijQqI0EleXnu2t/VP91oYPIw8jU0ErCZF08E7zV8MFwIw1uEwKUrcBe431GQmeJiZ9s5Me",
 														"4": "p6MHMkTWCgm5niqc4Ral++HPMqF17QgZwaDuDh27DVi7NQGyGg5QekiG46iXGdItBl/3+xpFFlWgL1buBLww5BSJYU3HWED6llerqQlgBHcrrKBkF4kYpAaEgzIFLwZ/"
 												}
 										},
 										"3": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "g4dRp9EfTG8rfWS6FnwmXWh/gXWX9jvOlcedb+UFdOYVG5wVOTH6SZDvgRM7kde2EyGT0vVjkHPC2OC9nlRw8Ssc4ZMoqlx/vsWmf8ZOCrabY6GgaBZCWLr0pdBvJ17e"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "h12FPTDhPZNC5MDrPEW8RhntDraHH8zw5EFG9AtPLBALq/gIQh88eZw3JeTf5gEJCr642Y/NQWKU5bj8fqkmbOmxZjOwFlWG1KWett1W1N6PtKZuOzfy8AZUyY39sNWJ",
 														"3": "reGr+sr8rH6J8M2jC5D7IaOTJYR3MsvCYTvkgETIgHAWGP2tZGjbElmP1NoPS5+dAlErLMyYBOKX9Lk0FzjpM8O8lmY6pHxsv+KcVRkkBfSHIMltc+HOfH6ptBjX3FdH",
@@ -360,29 +281,21 @@
 														"2": "ksd1CkWlubMFSRVed5VvcHFj07+T/EiEm8j6++Rp66o2az4M5pHQB8VBykw88yNkCfsQyz50IIQ9NiDvFYsWypItSxXC7zL3iNGxuv4bRRD1YvxhvSL5AOuKl7Ql974O",
 														"3": "oyIcr2S+Bc1wNiRG0f2kphYWUmGL6fDfgV9fffsr8iuqWGqMSB+OImu8wmPoTbwtCJ9be1pp4M7tYz6IfJYsj+2N/8gy/4cNl0ggN4rVf6N2pRYY65jmNlbxoWbfeZJQ",
 														"4": "pItaOg6r2zdBudc4kn77ERRRxb0l+eM6cZosEXUjR6F1DobfkiGv9RBNFVysI5wQDthcgNtMAcmV1iKmmjvkQasabIELCHY1YAorHciYQSeqEV235F+KKYG7tKZwAOTA"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "jVp1aEm9YJuYChNa70FnAOx1F6aXxic28oRWZt65THxMZU9AXpx6AGAeobLdcy03EAGXXjCYLEdUFAYXlafZmOFyxC2bpPVfRNvaaKaUFa9DzMkQxjI3KZjqBPRY2A2M"
 												}
 										},
 										"30": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "se8XJce7K+OuAlmQXUT/T48JupSKL7/c36SLAZH1YyFO0NWUs+GAvb/7LtpF+lnUBqOkY/9OIww1qr65ty+rH/D9b8XLwMJffIz4PTNYPQFL10gC47LBiBbGlvE11J74",
 														"2": "sIwzR0Oo4cIZceUy5wSTU48uJGRlh6OF0BUJ6CIm8LRM34Lf4FqcTb8tRVkXcakrBU3p1xVfjID8ucRTcrOBl5JpYx24GSTeAN7JlTvPzG0kLSTikgFSF0zu6ATpCSjH",
 														"3": "g7suml3DmISDH/Y7Lx95s8ZNx3x/QqOkFi857+YRjBDP0vqMLW53J62cxKw4SL0CBiwmC4lk1bqF6YJ3+TiE1BEtlPbNTe6bwUWc+RNyNhNOuaftmwBe436cZGb8KOSi",
 														"4": "shlt0MbpFOTDyhLCDJHzwPMlbVzGNRqvT2BjQbe0sG5V2/Kd6RfV0KSjr3qnYUAHBnQbC1hYA1KxDxIgR7doah9d2WaCQctaKZdweSlYADJcfBzXgq3n2tB4wIJwsMiv"
 												},
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "huTXfQMFljq5qlWEHYUK+cax2IN4PvMfhBjYiJMHjaTr/vbVhYiKWalWpVWJ8t+7CBV1im0Gi5f1IwLKJZeG8W6bdhEJmG/DRtl9IuMPXYd/DMATg8t87MGCMJXGB8Fh",
 														"2": "hpGOkn1oqQHu8cvP60AlPkC0aUSu0MWQWKV8dmOIKzWeh4YXEcXGaqXwUBKgd5r2EX0IZfSQxmAoUBdIzMigWKG0dOA/rsGSq5U6yR2nYLnsV8BWfcs9Pu/QJbor2Tpk",
 														"3": "qsmLmEnu4+I6jvP/BRuGZ2/Hh87o3nIrhzeZq1dksoec+KTXz9pr2UxiOhU4j0wLCxlf2vIc/W1C+qRA5HVKaP/HD2gmgsG0bzOVIjSpM65GFXy/d2OFZ7cwWfs/dq26",
 														"4": "mM2b/Wm06ZTObZ09OINYJ8jyJQOlWMIWr714tIvGwIGgu/aXV+lrZMx38mCV7pmvCm7OXCufJJyDW39oGCgFKR9iMTQmRRwQwG19miBTFCfKXuKrZ3kuhSNWxtbHs07l"
 												}
 										},
 										"4": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "lqvdPFWzsMkHhzooTJOfTPU70DL4BGI6eo33oZiXogtp5PfeOh2Jv3gR0kxSIPEjF2vhW/+Zd0VOIri6f2fBqDlVkSR6tI1nR87e3ZBHXESOnOe0fgrm+Bw2omjL4IQg"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "h4mvwP8tDp3VMMRYAAc/zh7642MVUAHdwrzijVIn+PRhXxtu2srO65TOhUZ7xxWcA7gWWS2QruStxXaZL6ZqVihsOZyKEd/4vyoz2jQg9Ay5f3C76yRPu+pDPgcURzvH",
 														"3": "h1SkoTV7yg7zzvLnx6wMDYxrbi1fiQN+mylDxpl63/KyynUmJV5N00BJnFX8bt+8CsPVraMroD0sImdnwjaiGc037N69GY6x8MXR+Nls+IJ0keT5d0s6NjfI3s3aS1sX",
@@ -392,15 +305,9 @@
 														"2": "jbWeTv0KFHqGy+PDOz+0NLc+i0pHEGYUnNZC3Ub+0L6SGD5fvU7Bw9B9v7SxEc9LAYtc3ABJIF/5V9r6NUj+znXzFgoBdV8YwCmPbt2yVnci6ZmAJCoDdnUsyXWrXyHE",
 														"3": "qlhMg1aGvj1woZw2PGP3GSfi6WPOZbJgwbbSYFdpNcvMoJLSxD0njvxuGFfuJNVkF6PF7FfCi8J5oI7GPr8qwmPwxbhgtvfejiU6FPXwRHvbG1L/db6Aci0k3DeBYF/H",
 														"4": "owraaSV8E4IJvOoWwM3qxSO0ammiOPlVFDtXaYyE1koj9optUv+2XyOmuFQyhRq7FuIUmj29kTFIYYjUlE0su3yZ3ZZzCEKaA27yiX7uUX5u1Nq5BhfFW5S9VeuG/0RT"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "pYFcuRc+gEKJ3CUgPN4PGwTeMxztgu5HxuhjjgqkwIlrHUeO+gknkS+m11xf1foYDa4nqQzUKoITdzDgGbE0KYGVaTY2WqrZh/I1L6dnEiqlPH94gkaoSu0hDrNPTnGt"
 												}
 										},
 										"5": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "q+C1reH7z94epYMhtc+omjK0aTOxyCuUeWPqOMmek/o54BbcP2tsjcud/30PoFxSFOAlUcZoj0nr5BjzC/ZU3JmcIMnLGcPBVhMoyLN0VGEaIDLG7kixOjuLtBhZwYii"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "jPXNUhmOmLL+1GFWsvnEZdjgXPcfOfJUpNRlG+I7cn49LhG6pB1vcee08mg0sFKcCNMmjQfcL/leITDxiTuKWGb8XnDhexlzFWTgfxqOOXSP6uLg4va7J1lNhSUoVH4b",
 														"3": "kwY9tRvCafaocc4mx46lkdVYqL0BoMPJDEJtF6Tjuk9vUIoVdR2Go9aaUuOrNJjLERgosRgc13E79kZ+ciKrn5fHhRXYLt/ehUOznkSQpODnx4EBsfVGntnS1hID66GA",
@@ -410,15 +317,9 @@
 														"2": "peJ0segFMmHUhwN5RWO95aA2ONZbD2e1u3JryOIJKhXUnwxs/+ZZFzz1yoA3ZcToGSzulYZBOTJOZybDN6rT31d0x1rHHP/YRHy+EUWY+bCOg95z2kWxQNgbJLSfcjF2",
 														"3": "k1FuqDaEttBZpKMYLOmwC8+ig0NCkdDKVMVcFt0N0IbyzMogcFeB+9nyLo77F0GaDFh00Ts1iug3l2HTkPi2BU5ZQCs3mgP689FZ3UxNNJBNMEm8Zqq7PHHcy6YX+qGx",
 														"4": "uEw+TM7J58tQUkmRQlmaCAg1Hbci+hJwb3mQAf69GCGNZNcrQeoY9HezHTPmjxywEfUMz3p8qOZQcw0nuK+6RI9S8Y1V8D13odLAw7gqF1U9FTqz0L0GYbUlEM8/JvqE"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "js9ejDO1281NH869+uCt/fsrybUsN8vegWBzqF1snfZWtPNl8nxikPEtj8M6SqCgFMQEDLZp3qeZy1r0Oo8RFT8qsBaWag6o/yAQDvsJDycmCFzR/28D6ncmx7WekOPe"
 												}
 										},
 										"6": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "iOGndN9TXrmt7gITrIQAkMzUeT8u7V+JgX/MIQLhXooLyg/lyuK9xhMwYT9cCc9VGbuZzjlfykwP1GqmSsfNRAHuK+Vq9oa4XeQ3BrhfrSl0Jgkq6azc0kQ+fyEaUl4p"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "j3E8wHU4XIq4D6cmCDSWYeW2vlJISQWtGoIFKMWERbsPHEfCx1Qahq8j2evf1eQWAITuFK7kAfZhLsiCbBT1j9OAlLAoAAtWc82ehPe7YOZDX211NxePPheOeq+10cxP",
 														"3": "hakdMHuuMXrfQAt/fHZOgckZHFseTb642RC7FIGbKMmCWWqU9KmI6IsNV2f8GEg8FpU7xbackS/3RRF0mXCGe9rmK7zzy5G7eT5V3qGzb/LipT6L7VUCqxQj6QynCFEd",
@@ -428,15 +329,9 @@
 														"2": "sc0tdHkKJ1TAPL86SRtljM0p/Hyze0sVB6QjqjjeYhSCdxia8vVhwXkZU3jh48OUCPdgD6cIA8CmBVE0jcEB7UyPlibO+l8o9sxhAjI0LeoxYB3TTWCtamkqagHXimi1",
 														"3": "rgbWp2EWoZ/6fztXH4/XNWRxDxs+a3j8lFkGcwAdM5xfF2d8iSxpMVv1ZGSzcKPxAWV1CQ6CvmueckJWYtn0rAHUB9FnGE4ft1F+O/tbzAFWxfiNQ8eN9G9AR6R6b+x+",
 														"4": "rQcRqctPjYgNd26jSsv4zzww0fBsYzOJevvpv/i3/O3yVohDnEeVk4bM+0ZRs+QOD5SSje3YWkLldHETOAyGZhiTRXv321/YdhZDtfdIviJj6DKvXkhhXStJ8PkDcBN4"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "hb44PZSzGkCc7GGQRyCJxP9LYdiHqqZ5au6jfDm9TmctuGNxI09s6Uxx6dwymQp5GPDJZJZo4uqUUM2rDCrgpLf3ktZbRHjDWGmnJSwm2BEcv9cGrbO2QVpOdNBr88ul"
 												}
 										},
 										"7": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "pyJAWFwm3M4Dajhd28+cZCYaRXvTYYZc8jA/cNrMU7QfuonpBAcrkGU8GHku73yeGa4Hh9KtL5FClWtsfsQuBaZRJ/k/sGQTG+i1CoRtLImPZS8uJngXkeNkYtjSr/JJ"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "htlPS8yGz1VwOnAjl20EW+I5v5AvvsZfNOtM+V68p2zfhdtxKxJePirZZRcSP7gsA5x9mhATbJyuMPlV94Q6nuwNLB5WAr3oCw3kMWseSgCqJbdaWvCI29xRo9GbBJRO",
 														"3": "s0JASYx6XTpPe5r6So2Fru+50uf20GH0jvP/sAP9kXgmdSK5ua+7UYNx1cU8mKdfE45MJniQVxcujoe+/HKuUmqxdSV9vteWbRcPbTiNf/oOOEQGkLY3BAi8sSSzAGnw",
@@ -446,15 +341,9 @@
 														"2": "pXUUzBeQUNfvhlMGrCyK5NL1Z6MAKMwf/3XBT+j2qkOjbHBMe8JNLQWH7XC0gRPqAHnXpXUT9jHRLyny1hkFLLTtoCi3xJu9/SxbQntUQKQO+Ztk8/cEb+s2fxpninFI",
 														"3": "ubXuAMGWb3apwbh593J0G3KgAu8kSfKTyWC/hDxKvN6L/PZ3nHtm2qD96MF9h/9ZAOk1+olC8am/0EasZjh51VloNnfWmYR8o3RlWuqoBMvVXEky6xVqm+x3vP7NQYrs",
 														"4": "heXqR1uj+hp2aeXVng3MyGraq938otx+3oIDfNQELSJ02O9zl5ixqG60NMKHp6tRD4tNs+gU8JKrsyGCUNrPGM+9xE7j8bQyEJTsZ1Umqqj/ClCpe5O6EMyQN9tG1axx"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "knRWV+8ECdTmmmi6BpykOdWyDe0ueErACD96t7XAk1F6zKiSCkeDj0nPbOA1ggYdCL1RHEswHtYYU5mkNlaN0Gse0oD82VYDDhLrYB3T7mqghjdnHYGZY2gLzCIxm/1i"
 												}
 										},
 										"8": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "ko3VLfglchTaOMdGYRm8SP13uyMFyLiltrY4pLZcQRIhFxziNA78bFfJ7s81mqGPAaDdRYdkACFLDee4m91DdwfosYHgISX+49ubJr25SU9MOmiFzVLxQH8Zt4FCY4Zx"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "r0unOS/vngI3gfKQETrOoXuUK4IX3w6ngddHDUJ0PpM+EWyO+ASVTtotE2EGOd5fAaq24RWpW9H/N2jRtQlVMtg9hMGvC4FHcB/UfGVhhMfyVEVGiG2UvlqL2wNx8lvS",
 														"3": "ubZbW+xsT6e9NM9w/y1AlZOyWaUfVTE8Un0emupjmksAuO9kjvTEEciXC8yR66o9FRpTIWIje29eAACZg7xhrqHN32JrnDQAuvMQGGBUOqEeLlUQgSfhkGZPmXI3/LS9",
@@ -464,15 +353,9 @@
 														"2": "oyxt9UoH+FBV1+fS0G6QUV6UQLEfiYvNcKykuCjqE8dK6vl/B29cAyZtKk6/lIk8FhDL3LpP6KRtqYQdzr+mai3yPfEJSdFHKxn60fCAX9vIleRLMOb0qgG7yflw/zGf",
 														"3": "r+TK5JOUkUIy+p+g/oajYt3hc6ka+8V9iIbuNkGshZI7UgwnpwEAwPDJK62Qr4x9Eued2FZNrYLAV5tD4O+vuX7QZCHGWfn9bkFvRxzsC4E3Ysi5INgFrLwl7aKPv7qF",
 														"4": "q1TY0btSXENpFBkWnZy1/opYuON9BKnC38zteNlOT8kc/fhWjUG6ydlvUuCG6yqNF4BtFQgA3q7JavStKEKy7C3m8Oa8OlT51XlAo23wdNYq8FoT/OjPlWsK1Va3HSzk"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sTWJgj5pcQtR5tm5OOH+Y4uaUpME6NYhckAz0Kc4Hbcro7aQl9bRHni1PqaqX47xAg4ANXmj6b54+WrUU0HcPCu1gZfFssQHft+Fu/clv63LHdAOXKYSwT3Nmrd+PHxj"
 												}
 										},
 										"9": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "jA1sy17OVrcTSkV2nzMDAU20R9pbj6Tea+rFvVxXAFSLT/ISUWq8kaioAICIAUlaB34xHBssOitfCubCUD8wsWjtI69ZZ41aAxUHmGPEdB1UEs92L/FGpqBQbBEGCKpS"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "gST3LLryARKQ+g5GBdZVOdw/WoF9amBkltHnRCrwh9aZPixwES3nEe3MozBgj39iA5TwQgAQaxqww2UNOvFj9zfpX9IFv1ORdftnWQq/aXIQeWTCwR+ID+PGh+F8DYVh",
 														"3": "q+dycETpu0yw6t588qbXhQ1iHbJMYIoTv3ZQRS2191JiIb3jIlp7mTh9a/J4Ed+SGSRiNl1pYz2wVgSeunOg7ilTrWWfhE2YD7Bz5R4ojqn7kGaI8k/NBgbfAeqflo7W",
@@ -482,9 +365,6 @@
 														"2": "ihXYnKSsyKO6YPedHHWLrOUlTPn2Ys7+lXGK/K4ORwoAgAgi1XF+EOPPFgcy9Q12DhwgAc/99I3/You1lgSsCUMDOMueV5mh982UttZ+R+3x9c7g7YPfeSJ25rgrPCLt",
 														"3": "jMjonsK7YSLJhO9JLZf9fIb/Uz2Ladrsl4iuD/UYK7cSXSNblZl2cXYI40MfGlBeCsE0N+ZQhcmBNLVZgbpFQERnaV5eB6i2S6GtrkujN7FjmVs8eEaPGxXa+1vGLFPF",
 														"4": "t96BHBI4og8RYeAEwF8dbFPkxejW5oJJIyBeX2fTbvV9fu2e94Ym3R1AB8ofL9E/CtkAnmaiL0Wpj/uEAHkXg5kNxATcn+FNQmehiKHxxpPkmEGZsz/dEdKjkv48BR2U"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "smyCwv3zWMqQeEUWMc+8FGin7BHS0ZnbGB0wRar+bjDA1UsN7TipHpsf++LbtCSdBRBanS4K+2wZdTmHdarBe3MCPtC4Nw0t1tUO+GDKt6obSuKPOiMbX8S8uxaYrSpl"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_partial_invalid_root_quorum_then_valid_quorum/attester.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_partial_invalid_root_quorum_then_valid_quorum/attester.json
@@ -8,9 +8,6 @@
 						"PostConsensusContainer": {
 								"Signatures": {
 										"1": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "hPxPvEgkWzxdxL826zMik4cvoftHnuPt8q75/SvaXubVR+eOmyFn4DcVCWHSpKNlDYlvYe2FiRgMmf1Ix+N/YTFn7h2nxLblcqB/upxvTN/r//SQVcaZEsoIPIYhJ/L0"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "omdKVvZREI7/13r/MEBbZ1qvOBDvcLZmv5wc+8c2+y6dQ0pc8BekK4QY0/3z2ufZB/3acnuYPmgjt9BNA7GSbKiaru09wf98a1Ci7RfKsd15i1OrDfjbHwJyFcJOrGT0",
 														"3": "uQW6KlBVbmO0r13Do/b+5Q0DRwLRUtN8RFVJGNltIK9wnuu/9JJ+yb4gxjlCVEMFGT3s/qMrAjLovxVXml+kPI75ibSbbxnWVc0uiIhCvY5s7a8W6NKz0swFAyhTFuL/",
@@ -18,9 +15,6 @@
 												}
 										},
 										"10": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "goaFXTZC9LxayNZOmR7Gg4p0SV3hEDHGB2n1Mt1zT48YzTA9rdTcCqbRBg5ZBkeOB2YnaUFy90HGgI4oUBtWSFPLnPYsHninxjPkrg45GU+2rV/xRzj/z4aW8BQ7B4ZB"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "uFT5oiBIUTZk+hE+qhrhlxM/9fMr506mVIWsJGpfpFkZlzfPd4HPNXFkk3F+H3wWEiKcyAhk8mfXDOqNmeccI7XX2xM2Q6atvAoj1IKvVE5qH1n66CYrvxcCWjE65X96",
 														"3": "lZr9/Z6bvXz817/xtfX2DXRzy6UktUIUjX5t1CV9k89cM5VdODoYeEM809atwfjeE0ozkDGtnlqQ1SaDZQUBNdp+t4TcoI6orplL9zAYQgZSpxldhORFZCEiYtZPlB0Q",
@@ -28,9 +22,6 @@
 												}
 										},
 										"11": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "rdjQ3AT5WfrEijcy8kMyD/3dNL6EAuAZ/Obcd5smKye/SyMOoVst5vLls4V9Ee9jDHK/9TNYbJWbLSeUJf8SEdLbzjfcwoCwWeznLb47dW87u1rIKfcgLGv6odxJ1VdF"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "i9erMzrBV7o15BeeWfvcCjHXQNMYFzSS0CxliVIkhh0rlYrf0nmwOipXvcuXavBpAj9Twq8GyOxzDMmKcXK/Bkes+8tDt8pEPOBu07ovibYFW5SALizIq5biDzjwTm9D",
 														"3": "h0H4Jwf6wyRBziYbySL1TJvN9gNPdDYoxs5/l6tsaJ0mvRIlAGvduNYHVeNISAsSFKdNlkEIMXxbjJFNBaLc299NKDKAl4Ij3U4vtvuO7/St+eNe8wBJirlLiXUu98lz",
@@ -38,9 +29,6 @@
 												}
 										},
 										"12": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "t1CV1LsIK1j0nqgdoP+e/47lk+xgjxUcys7UUlP+/zncJT4dtERrzlX99rlRvJ6kCgPEW/XkEZaNYF3mq3RQH4b8PjLvGkJJG6dUxd76o2w5Fq0kpbwD/wuIlZyb0zOH"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "hHCVLGw8+8sqjybUiGSxkOdQ2NqQmiYBY9msTNZni4IEGvo5RhH5rMMHxaPmWrViENEHYFdRHDeE/9R5zzJiDPJG8ApJ69xa9V081BkNa5lrZsAFbluBNN+NWIpB0nhH",
 														"3": "p1Zs5h1zFqG7moqqUqNoYo9AVqLZaB7cy5xgX2BZTNBBwyZVb/OwhwOrnZYwMvXUBB5RpKBHkYen/Y3qqsneR7jIWY2+cdGOv5nsus5+BI7q2O9LnjPpcQw38aZX3TEz",
@@ -48,9 +36,6 @@
 												}
 										},
 										"13": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "rnAPozj3weuSiz3Sk5rooxvUU9AXIMbnZxpYeGdR60SavHxYVM/eIoBiMoXTu3kyDt8zOsE0XWLAA7re61xDmGbqBVsMoc7MIGTt23WckyobhR1cWeRMRMqZWYLbSANX"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "sz4rLoe318wR9oyobOzUcY1VXH6h3xUt1b/fF1syqtUt+Tv5/MuqkVtS/cMD7Xh/GGI+QxE3+c0PgiynyEDo0E/9gMChu6VzZxL4hR6LktwMSl7vxdxiaeeywYepuiuC",
 														"3": "l8yxg8e4ohN6sIGwy1qNfxGsupNc0q+PUhRct+fE2pq78HFLZrlg8oMtvGkHIYubEo9uLnOFEiqrIibpOEjwJy8qWJH3UMwS0RPz2hOseubVYLZwDY+WAacuKT+VpPGv",
@@ -58,9 +43,6 @@
 												}
 										},
 										"14": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "p9SGqtQ4BXcmPO8e0Kj5AMdGbY6G9exrqOmIqakk/m4Yeux4LYgoSqa0lT8dUOmhAWmHAQ9WRDQ02PFOFy/bCRSJK0ScKOMY9anUErNRpmKWrrwOseZYs5YHlrsOnKjh"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "j0mUfExFA6YJTWeMwNighA19dsWNYXqUa0PyUQJmyYG1ZAa5IqSaDGGDVVI8FQbKBF1GWOH8C3rFxtZvfaHdWqbLgqyY5Q6m68p6byooGSAiYMzekOcbdsLcNuMAiux/",
 														"3": "l/I7BT6qF8XcPRtZls3NsXpL60/Axpu8hwnZX3j/vkWKUPSwcKVCoSdYX/xEU18oEXGkgfejM07yTEa4jxJJkoNQbsP5cTjJhBbqvikJcw4v53SNELGcvTaj/z7n01XU",
@@ -68,9 +50,6 @@
 												}
 										},
 										"15": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "rFXBCpa5nJWtN/XJ8qZrDsUdOeFtAd3XgV7UlOD8OsUmujhL/I4WnieU6sc3p2AmB5m9nz0tdnX1jzbv3jSjB8qDQPwqOGRVWK6Vt1cNhObIpAv706/FLkcbquCreOe4"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "gBTbwkrVbmENCIZOVkomgFWtf2BN6iGZJy6UCJE/EkZnM8Jw+CvKtIfWyhpLE4KiBiWsv+7ZNVrREdlOtSEor0U9VrTUnblll1oDkVfx4+FxFGnfJaKTlfO/nolh5WHa",
 														"3": "uchxgayGffvLZ6kcsKJbOAkbxaD/6AQ8TMqrRQES7BY5Vjjhx5sVuoPY6P2llQ2hCwBOWTiinuFpo4gHZKpjmIqCP9C0HgXT3wnUnQuxGyZoDZibZLLlM3h1Ib4tbShH",
@@ -79,7 +58,6 @@
 										},
 										"16": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qrLZg+F8YTdsMlkfH6HkQNLA8plNo2swTbudf9cqG94MHL4oC7lNBf6wh9TVNiQZBt+I59lO1kwHHzccBgd9abnYt56ByMYiyqBohVhK5OXYLtfe3IrnIfrVRHKol2bC",
 														"2": "qn6Xq3OhyegpHgCwI5O0bI0Qvbz+/wX2wmWL+U8ucFq7AgOTtIbHei6yrrPLO2D3ANk6tbGGNaTRvnUx2vkjtCJj4EGnghUo01fh8q+u4op3rykBbSvjv4v2G5tO7wdz",
 														"3": "gjxWlb7sLTZ5fJWUwp0OvpTTE2VQA2E7jX0ZbAQEPPBTJtT0/GBvr1CbUgAkR66qDgywTBCblQAcj2/dEF8gBEzQae+maFOodHmrLANX5mwBj8anLJOWf9ykMRKBWH0J",
 														"4": "gYJ25sa3GOyH2vsB/XnY8TpNQQ7DwKtY7lSJ7W3hKG5PgtR4y1VLcxbcHTxpJAIVB+sVikQVyf0gk7YhsD3rrPLKwZp7iimaEASdBvUvLzDVOlmbG1r8z+ShUe5Yk7Xj"
@@ -87,7 +65,6 @@
 										},
 										"17": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "rDYmDfb/MA7Td46qFq6aTiYowqMNCAC0yp3iZSglYyGULb/cU/RhJriLZ1ohJ+zlERyfeTCPq+IgTrtSZm/gnqJ7fz5+PhXeZGfBx1ykd57NIRZcmc8BGq/9/yXwt1Of",
 														"2": "oSxp4+0P5dXvHwVnIzyINy3/T7S99VDBwgcvi9TyNRuFg6OSzqvYxF6wXwkla4jMBtrar9s7b2WM5s9oFk+lUUzdvZoAbGXuI2DJG1ZNQw+QxJEIBeWCHdu7hp8+kFt3",
 														"3": "imz6LUIqEO25R0sXTSqTq2qKiONMqtDKc63CaRDhO5bQ/NRxk4GZv8Du3r9cm4VRFQfp9eKkCjozZJkMwKRIVPoBQ0jMQiaYNRYDwcq2nyfTayVPZHtxKlfjo0CiHvFG",
 														"4": "qqkQFPNcRCDAN0lzG3H0J6msU7/HeGuWDy6YpMdfm7Amij5WuLuJnZw2Br5liEpKF3vm/5NPpesrWMEQyyggSgqYgT3/2xo3aI1G4VAhCdiS6Sv1zvKZKJ1bvmjgB3qS"
@@ -95,7 +72,6 @@
 										},
 										"18": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qfYO1PZnOdyn56KlUf5UuWa4T/udPhGQa5VzswkWlCLvHifs1UaID0Jhgs+tInD/C0Tczf2Ay0w4vDqeJ2anSDzdzDQcm2dZfyfCjuKSoydsUSPshEguUTmUjBvrsYMh",
 														"2": "o/xcYlHccz1LY4QknL3Tm4Eh7ypexKW1s0Z2WZguRhtZkTyo2gOuSPZ4PZAnRhdXCmmCu+zyt1IcdQ0sJzBnpg7kbukuDXnR1edSVZE+E4wEQTd4zY8CgBhw2OHolQkd",
 														"3": "rhi52z9Lner9yKFOeJhSFREE1Co4zcwII6ammqHuMdZsAuYya02PROT5Y8iQH05sA3UVygtvPe71qP3ZvDX8u6N5g2R9IYPgTO/bokfHgWelqz9LXfGVjt3fLvKiKhvo",
 														"4": "hEj0JIGRdv7CNON3vYATgwobiYa+LS5CvVRtc93Br/BNRgWnmGCvee2kB07nR0rUFeSH08IpXmyBRpqvngSMH5eHG9Yc+NMgw2phnwLj+qFyjnCwNJDtuvnL9R24Q+Ux"
@@ -103,16 +79,12 @@
 										},
 										"19": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "sQ/J4kLWhiaZ08IPAr4F/Qwf0jtSFF4PZq+FTwdoyjw0Awv6ez5379hzsxAzOsXjDDfNFYA705hNdAx2pgbkGqI5OFMAoXzE+RNPG/Q1O2GEoQgU84lqXIH/rVSRTR2F",
 														"2": "gvHoto1Sl91Lrm22L/jtks3/DjVGoaQJu/2zKIdTprIQqeCBfSAF5/lf94hWNljQDEJ9JCpB9U7CRA0yb3NK4WB6LLoOE3YcjR094eeKJjPTxUKpZMENdz1tlUksATJR",
 														"3": "lxsam3hbJlgYZtncajLN7DfgM7CKDxusZLahyRtvHg0vGeENUagtTbnjubLNnWWbCrxCkaA9dcCldLDuU7MKvzKQ0gZFXTREe7eMlLPy2b2IFTFCg802E1NTVHuCXVfB",
 														"4": "obkn9oAb2C4VGSkSDPdywNt9nrmmnYvG7+H2bWNPKS4OupPhQQOKIevnHGI/PBUNA2DSfvVYfcGUzj5AISurZyglV7fm1M9cdlfd3ulzZcjif8s5jDUkhe2u5xL8mdTg"
 												}
 										},
 										"2": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "kSssanFwQeiweIayePbTZm8t215xD4x6Qml6BmeA3Lol1YDy+CmdTd3WE9vZd6V1EJl3Qgm8+z6RO1+Udb1a739gQ2bGbkaLDZ53nM8Y3hITrOkeGHPYY8YdJZ4a1DA1"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "rfSh5SGDXGU4+wUZTg1uUUFYXvEykDWGNFTO6xOwfrLh9SRX1bX58svbgMB1iY2LC55FnftDnzNUpyhP1iT74vlOFV2ucgtJmmzi6w8LfoeLAFDNH9qmgMIz4qUyxKsX",
 														"3": "uNUbp+nJxYnHio6dpjWNwpNggxCPPSZ/wnTjKl+c63Tq7a5FArduxzaCSzf6bPKLCGNiToapuhCVDK/PA4Ty+PrbfWM3raqpja7ztXOsnwrR2siA58lL7G3okiFgy+oe",
@@ -121,7 +93,6 @@
 										},
 										"20": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qUELJnr1KxUV916E46+hyGCSLLbK02w2OmIOP8ex5Pjz2c8UG02CNwSv9O8/PfjtFYvEGd1NGqpvRtrLLFAaYWHMs22zuIIGHWtG5j+HZEj20LtArqRA+MSC+EE6qlFS",
 														"2": "h0oqbOoUtfLAWnIBb22Kr6ROIsj2s6diqumtxAw8We8qyX8TIrQ72DYCqhNz4PXWB/JoOmabJCzwXqWLt9Sp863engVBFv67iihOTDm4E6UCDpTk/CTz4GCQOgVVEHGE",
 														"3": "g9XNNJFiyCfZmDiZ6APWSaqb5nQcOmVBJFZWqVyuwj8aMqySmBVhleJJnRfqGEG2Dwyt5h9rV+aRLB45rdVD6lQM3x+kCbqnM1QwxVdHnRP8kBVkvcy/AaOhjfnY9Elf",
 														"4": "t70fysV7wB2FgSeoUEspWavbtSf6tNYrMisp7c9/FhPdmkDeWKfVUB+mykxzxZBqCEcW975PxO0mIqe+k4igsdB8UtSmPWyuj4lu0yuCRzjV3BYEdSn8tzUP5+sOmEzs"
@@ -129,7 +100,6 @@
 										},
 										"21": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "tV0jeFgwmLoHp7iA73rjKzCBc4sgoONLTGk+dOdcais/g49G2IS9No5aNlG5S2xYEfbBr40CROeiOjGS0yovTsgnWqb/lcABzqy9Nm3k1pURlHoW5/QfTwpUnfNI7Da8",
 														"2": "ljl8Rh8wo7OoB5P4C6FIuBO/45viKVU29/qUWVbAr2xy0v4CTIlrFnwxsR2qSr4GFeRWT5KHERF+Ob0nmUrc2uvoSM+EfQA0iBbfA3z89vG/fsrpIPxlMC+53NB9Rdtx",
 														"3": "ipsiz9YXU/XkvYzNB7yyd1g9Ahr82tW1wFGqzBZYoyPb7cbpxMbwWDf8p/Ixg8dNFuyVDuX14kNe0XRa/4rUQYRACxZ8WK1WKtYonHblhgMYUJznELfmbHqTTiSPfj1h",
 														"4": "thh+Ng08PXB+0Rl+Yff+RUcqoGimkPQsXUVNkF3HtkjrUj9ZlOJDp+UHGXLxyXWPBy1X3e2cTNBinZDPXVa4wL+QKL15C4y5CurJelQ2z1oZsS5zhO6789DMeZfLuQaY"
@@ -137,7 +107,6 @@
 										},
 										"22": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "prVC0BIIAclwtPSi3tdiL7VkuVq7PLh/xQYHEBTb3tOSDbLSFK2UpVIUQm5T7BrqF2FMyvn8PzAK5mksVZzSybnHCgfWaxmodl2beuB3YJ6fS9jCNrPDxMS+lszAoEx5",
 														"2": "oNszWGYnHYFqflF46LrpIg9rByZv4zTVxaDjwNAvhFACSzd+9Q8o5NKUBn8awl4FBeuzg4yyBhbQbu+UkUvzPE/q4LKqIXe2F3Ok9X7SgbxYoSP8s2G/nbLFLV8IHDDn",
 														"3": "lWsOcnc05uj8tGLazN+GSe/yYFo51DpTXSHMxWNnwUoN0E6JAdNccJPZtufs0BuaAIOpikPuhyw8baDASvayDQOBnRFPV9cdQhrdwBuTVTs8CDsOUem2zHd9o3CyoEnT",
 														"4": "sWIgSY6Nt3kK52pTkruYmRS8QBtmJgbSyYPHH32W7/BspwOrU85ajQy8W2r9ON9EDN3vuwKCvM7T0eAuo2iGA8/Ky/AZRoKyR4LJ9Do+e1pWreeNkTr8pHRDv3gdw0k6"
@@ -145,7 +114,6 @@
 										},
 										"23": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "jcaYz5lAMroNTkHoRjpu+JxQtxEQEsXi3TvXwNZHM03vu6W3SWGy72lwngV+dklqBLHj+zygF+7mzjarnU4X6LuNTsNNBiT9YZXcAiHBykh2O+NGC+VbyJagE0RSJbBU",
 														"2": "ucBgoM+v//i+5+Mp8AZVnF1dZHJ4sFY8ZvtftEGlEvThPCHKSAw5z9rdJdMjRKXjFw/Uiyw0fx3CcOh/9RP9rvjN+vJIvSGt2z/+Vm4m3UqpGrco5Li4DsVV5iTDgKgL",
 														"3": "qDVaTIfjZvog42kIm1ANNoRDOxJODIpvQ5iSwGK41g4OrmiCQJJ8zS982UNzIqaBC6xj5RlYdifkWhn5DEioXJJEFlg9HdAcQyv3D7oLHtBtNxqrWNdM5THACwTiyndG",
 														"4": "p6crK8wfZ7IQt86yrHpeJgyVYe0YJ22xVI748RFbOYMKGuMVvpUkS9Ak2KxwoAEwBj4KbuS0KKWBiE4elmZ72raX9zpdv7eJkiXVjcHz1kvs4fVLv6mAbz7m646Lk+4a"
@@ -153,7 +121,6 @@
 										},
 										"24": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "rjHSe7uHZhyYPv94E55ITjsr20Ni+VW62P14u554hUsuGn8dI6fzb/HkuMfAeEllEwTMUw/t6ri76Wy4wMu2pag79UtXbbvwUMsWZ1KTOWpXms+gS7cDK0Jz02F5z5Ov",
 														"2": "sUAbdrFua4IM56sJQrMt5qmA5Rrf35yiQICg9gmKCnOuat9MkYqgroh8bM0q6VsaArbddrSA4tHW7VkBT+7P/SvyD6ovP+oPem726ssKRz/tN/IqAn0RlK4jvx+gJqcf",
 														"3": "rcQTjq0d7mZTx/+AhphQtUbFdTDHC8EUT9JHjTE60DhdFFX9oK70sD/lGpTIrj5hDapR1qCAzsCZ4IZ/K3SVKxedaKxtz2wEHpOUJ4c8IlsGaVhiCCgJBrDlTn8l6t0l",
 														"4": "mOFtm9U+Gk8soblK3wM+cS0SbfErv5oBcl8ygRRraxyE83GfF+o+E4oLZ3fMLFwaDLd3fNnVgCvlkijSsyXwH7ND3bXt2VHXnB2ZDgPhV6GBheyYN1u5hgqPrbT7jG7P"
@@ -161,7 +128,6 @@
 										},
 										"25": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qcSAock9TBLMFdhicYg6xbaFgwkk9mdj3AktJZy8+vD0FBl0Cw1NkkGLwSX1kszCDTNjVy8hLka/oUkNkI6IzBM9ypwLeDQjzL+61K508QTbbNvV4EOmQlcp229vp4AW",
 														"2": "mIekuezgwsxdPPd64DhExZCw8BEkzmthyakhVrcYoMMCjIvsUgii9KKTj17oQARxCPb6VZ+rg/xblh+DfZbRuxnOR8x5tV7zlDnuZdDkBIvW5/Uzn/c/gkbcfMjzRMs6",
 														"3": "mUCu+YZDE9RFeoCtfsaeztunlpsaZ8ofWqhCd2ehy3WMsyAA5ybXHa+5YxLahlP/FT4FjJ6LtH0gYi+IGAm02dly9O+JSYFgn9YyIQ/lR0RPoKwHeEagpB5J4/GvFbPC",
 														"4": "i4HKJWvWDlJqU9sEiDuiLRSdCxBhmQUE1G6XgbTkvqjwzWHIfp8Xomj5MjRBMNDFFCuTnCtRJjzWjvRP8s3rHC6kys+XUfiogpsRhGsS/iYy06QAmo6hVFeB7j7iITTq"
@@ -169,7 +135,6 @@
 										},
 										"26": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "hSkoW/2cKCuKZ2DmyQNdSeofdnayemj2h1/0FdxvkNQBCUujyV3RRT7cooETaP39EhVg803ZxrXwgrzl9Sn/Bfh2t6Qj4kEFNgKgaenLkoe0wK4BguPr2PGx+bovaV4k",
 														"2": "oYm1gQdOYnbj8vQ9pxRWxPRx32B5SzZk+WROAJ/KHFTln2isY6fY2Uag02bzmFSjFdt5AroJjxl9sDikKPwZr/xEjHpY56nVC51lH8dsafV8UR/qDIl3DHIyWIKZdFmM",
 														"3": "k0kt0+fNeNrsgxunbjBh5C7ugF5rZYHED+EvDPM2qXfkJONFlJl+829MlxrUT3aRF6yRIkbZp9NH+uNqbvkiZqBKZ+NfUTrbjZrBp3xVx/bPM5J46ZAoxs/NoqSFaOQr",
 														"4": "klP5UpcOPNPh2FxQ32rdF1IGt3omtppZurWw2OCumLnj3w68LYyz/gdpes82/E7QAxiTKq71BR/Q0qPGyOSee/n2wxXu2AUmtJqxC75dVdX0fiuUCdsGiEBP3YXFIKfv"
@@ -177,7 +142,6 @@
 										},
 										"27": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "qqOz4CV3KEm9FnJww5SPaJbbYRB03xXsFpIWOs4Cn1evdXLSNkuAS+F0VNJ4ZPq7DHUQ3Ztmmmwot2h9uxvBdCBpJ7D17w3N5A9x92M/OQRQNY7T/R/3w+C1N5tRpfTw",
 														"2": "kOpk7vlBYf0P6w0Nnjqo2E9LOKKbzUMyWk359kCZHBprB+dT0Pgj4w7sQ0vEJG6oBGR5SZbaOcofX9VEAB42COxsVRj9LG5LnNTMRm/TjYPNi8Y9LCcvZ+QxVQBENJhz",
 														"3": "kF+mZJM0Gr3DVTw9kf4xysNhIm0Wfrw0MJOE0QwVwQFmmT+jH5mKoPIoOii4KM1iBTDR1peq5DgdOucSjTj1idb1MV1/vyPzHR9SSHLDH0ziSYMNMreHwx69lon6Q/lH",
 														"4": "sKRNnqO8yhynmDUAbkX+tC7QoAkn8OxaajA1/2ZgGY8tpcdICpwTqyviW7zxyJpoE2QSXMQXWUUGweZEvB0woqDL3/qd4aOchiQRlJ/3iEN/cjLVFneiZsS4Hq4YAXPl"
@@ -185,7 +149,6 @@
 										},
 										"28": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "hvYv0KSXYPVpr84wSAVAS9LXBF6RMan1PeePF4WFRGlFwwOYlXZlg4cysTrxeWAYAfIh49mZN9I4DkR1QiNqJdEqHjI34h5ScWl/TNWdV4snevbKgySnle+X16U2u5uc",
 														"2": "tKYTWsAxcESRXu+g5kq/gcPBvEvnZcbvFGH2vPxYr3/Iv8XiMVOTwMZUXjvxTzeeAq2Y0hUlHXmUW54nFUvNgfmwskjACnduq1PZPYJhAgW43THW8RdjQVAUU86UjKjo",
 														"3": "g8Zc59aDLWLvusqJofw7G+8SrmjhBhP9pH1LRK4jl9e52bo62hGc7P42F2LNMDETAod6K/TVydOa1FPdaQ1q+aH80FnUHTa7b2SA2k66rriKKVm+CeMMYt0axLnMkgHN",
 														"4": "uaEBuC9Xr8lhTaMIawscBN5C3AJ0Gh4xC/dYbAfwOf6aeSR1fTJ3w5LJG9az+cvfB10okm/Z8h74INhnGh1H5ri61XSmAMToA5w/6+mnMm2kxtI5dSh50dluTQZVbml6"
@@ -193,16 +156,12 @@
 										},
 										"29": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "tHbasXyE/fsgcrM6VAR9T6vSZTPh+kCfLnNzwdNSvQ+P5XRDbN0muYqPQvYHtyBbDtA5ertEbkPHoxo9sZVm5ZSm+BmWKZPm7AAgrLiwod/XWBuyXh/tXs75j30Q3X01",
 														"2": "udGw+OBRqRqPrVWyKwbg50613UYGfFkPk9LPhmj0Vs0xpR7dWVKCjfN13KUMxz7gDWq2YO0kslD6tAEtzaJ7Vglq6Y0cE1mDylRFdYF5ErUV21voqIbIhEUepbOyJK0c",
 														"3": "l+7PGQli5R5kOTX5GGzTsI6ht5Xxv5Jizg4rUAO5aajxDDVLxaw+w4y7yElQteLzBHdz4cN/773dpZtf7tqXNqa8sf3maYN91O7ewWnCIuMdm+wY+Nk2DNPlNBIliLql",
 														"4": "lems3rs6CwuSMMG3R8LJOUNcSiNGxzbst+vMyI5SMGNk6dnODPbPVLKKnljNkilEEYONiNvvC7Y4Z2gP7llSzGQup7ilWqKA+uhU9xmdENY5QXbwJWPRmIhEDSOseCyz"
 												}
 										},
 										"3": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "g4dRp9EfTG8rfWS6FnwmXWh/gXWX9jvOlcedb+UFdOYVG5wVOTH6SZDvgRM7kde2EyGT0vVjkHPC2OC9nlRw8Ssc4ZMoqlx/vsWmf8ZOCrabY6GgaBZCWLr0pdBvJ17e"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "h12FPTDhPZNC5MDrPEW8RhntDraHH8zw5EFG9AtPLBALq/gIQh88eZw3JeTf5gEJCr642Y/NQWKU5bj8fqkmbOmxZjOwFlWG1KWett1W1N6PtKZuOzfy8AZUyY39sNWJ",
 														"3": "reGr+sr8rH6J8M2jC5D7IaOTJYR3MsvCYTvkgETIgHAWGP2tZGjbElmP1NoPS5+dAlErLMyYBOKX9Lk0FzjpM8O8lmY6pHxsv+KcVRkkBfSHIMltc+HOfH6ptBjX3FdH",
@@ -211,16 +170,12 @@
 										},
 										"30": {
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "se8XJce7K+OuAlmQXUT/T48JupSKL7/c36SLAZH1YyFO0NWUs+GAvb/7LtpF+lnUBqOkY/9OIww1qr65ty+rH/D9b8XLwMJffIz4PTNYPQFL10gC47LBiBbGlvE11J74",
 														"2": "sIwzR0Oo4cIZceUy5wSTU48uJGRlh6OF0BUJ6CIm8LRM34Lf4FqcTb8tRVkXcakrBU3p1xVfjID8ucRTcrOBl5JpYx24GSTeAN7JlTvPzG0kLSTikgFSF0zu6ATpCSjH",
 														"3": "g7suml3DmISDH/Y7Lx95s8ZNx3x/QqOkFi857+YRjBDP0vqMLW53J62cxKw4SL0CBiwmC4lk1bqF6YJ3+TiE1BEtlPbNTe6bwUWc+RNyNhNOuaftmwBe436cZGb8KOSi",
 														"4": "shlt0MbpFOTDyhLCDJHzwPMlbVzGNRqvT2BjQbe0sG5V2/Kd6RfV0KSjr3qnYUAHBnQbC1hYA1KxDxIgR7doah9d2WaCQctaKZdweSlYADJcfBzXgq3n2tB4wIJwsMiv"
 												}
 										},
 										"4": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "lqvdPFWzsMkHhzooTJOfTPU70DL4BGI6eo33oZiXogtp5PfeOh2Jv3gR0kxSIPEjF2vhW/+Zd0VOIri6f2fBqDlVkSR6tI1nR87e3ZBHXESOnOe0fgrm+Bw2omjL4IQg"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "h4mvwP8tDp3VMMRYAAc/zh7642MVUAHdwrzijVIn+PRhXxtu2srO65TOhUZ7xxWcA7gWWS2QruStxXaZL6ZqVihsOZyKEd/4vyoz2jQg9Ay5f3C76yRPu+pDPgcURzvH",
 														"3": "h1SkoTV7yg7zzvLnx6wMDYxrbi1fiQN+mylDxpl63/KyynUmJV5N00BJnFX8bt+8CsPVraMroD0sImdnwjaiGc037N69GY6x8MXR+Nls+IJ0keT5d0s6NjfI3s3aS1sX",
@@ -228,9 +183,6 @@
 												}
 										},
 										"5": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "q+C1reH7z94epYMhtc+omjK0aTOxyCuUeWPqOMmek/o54BbcP2tsjcud/30PoFxSFOAlUcZoj0nr5BjzC/ZU3JmcIMnLGcPBVhMoyLN0VGEaIDLG7kixOjuLtBhZwYii"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "jPXNUhmOmLL+1GFWsvnEZdjgXPcfOfJUpNRlG+I7cn49LhG6pB1vcee08mg0sFKcCNMmjQfcL/leITDxiTuKWGb8XnDhexlzFWTgfxqOOXSP6uLg4va7J1lNhSUoVH4b",
 														"3": "kwY9tRvCafaocc4mx46lkdVYqL0BoMPJDEJtF6Tjuk9vUIoVdR2Go9aaUuOrNJjLERgosRgc13E79kZ+ciKrn5fHhRXYLt/ehUOznkSQpODnx4EBsfVGntnS1hID66GA",
@@ -238,9 +190,6 @@
 												}
 										},
 										"6": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "iOGndN9TXrmt7gITrIQAkMzUeT8u7V+JgX/MIQLhXooLyg/lyuK9xhMwYT9cCc9VGbuZzjlfykwP1GqmSsfNRAHuK+Vq9oa4XeQ3BrhfrSl0Jgkq6azc0kQ+fyEaUl4p"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "j3E8wHU4XIq4D6cmCDSWYeW2vlJISQWtGoIFKMWERbsPHEfCx1Qahq8j2evf1eQWAITuFK7kAfZhLsiCbBT1j9OAlLAoAAtWc82ehPe7YOZDX211NxePPheOeq+10cxP",
 														"3": "hakdMHuuMXrfQAt/fHZOgckZHFseTb642RC7FIGbKMmCWWqU9KmI6IsNV2f8GEg8FpU7xbackS/3RRF0mXCGe9rmK7zzy5G7eT5V3qGzb/LipT6L7VUCqxQj6QynCFEd",
@@ -248,9 +197,6 @@
 												}
 										},
 										"7": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "pyJAWFwm3M4Dajhd28+cZCYaRXvTYYZc8jA/cNrMU7QfuonpBAcrkGU8GHku73yeGa4Hh9KtL5FClWtsfsQuBaZRJ/k/sGQTG+i1CoRtLImPZS8uJngXkeNkYtjSr/JJ"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "htlPS8yGz1VwOnAjl20EW+I5v5AvvsZfNOtM+V68p2zfhdtxKxJePirZZRcSP7gsA5x9mhATbJyuMPlV94Q6nuwNLB5WAr3oCw3kMWseSgCqJbdaWvCI29xRo9GbBJRO",
 														"3": "s0JASYx6XTpPe5r6So2Fru+50uf20GH0jvP/sAP9kXgmdSK5ua+7UYNx1cU8mKdfE45MJniQVxcujoe+/HKuUmqxdSV9vteWbRcPbTiNf/oOOEQGkLY3BAi8sSSzAGnw",
@@ -258,9 +204,6 @@
 												}
 										},
 										"8": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "ko3VLfglchTaOMdGYRm8SP13uyMFyLiltrY4pLZcQRIhFxziNA78bFfJ7s81mqGPAaDdRYdkACFLDee4m91DdwfosYHgISX+49ubJr25SU9MOmiFzVLxQH8Zt4FCY4Zx"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "r0unOS/vngI3gfKQETrOoXuUK4IX3w6ngddHDUJ0PpM+EWyO+ASVTtotE2EGOd5fAaq24RWpW9H/N2jRtQlVMtg9hMGvC4FHcB/UfGVhhMfyVEVGiG2UvlqL2wNx8lvS",
 														"3": "ubZbW+xsT6e9NM9w/y1AlZOyWaUfVTE8Un0emupjmksAuO9kjvTEEciXC8yR66o9FRpTIWIje29eAACZg7xhrqHN32JrnDQAuvMQGGBUOqEeLlUQgSfhkGZPmXI3/LS9",
@@ -268,9 +211,6 @@
 												}
 										},
 										"9": {
-												"1ca961cb1436f22e2a67d2aa359f5308c710d17767424cb7e4cb07d06cb1da8c": {
-														"1": "jA1sy17OVrcTSkV2nzMDAU20R9pbj6Tea+rFvVxXAFSLT/ISUWq8kaioAICIAUlaB34xHBssOitfCubCUD8wsWjtI69ZZ41aAxUHmGPEdB1UEs92L/FGpqBQbBEGCKpS"
-												},
 												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
 														"2": "gST3LLryARKQ+g5GBdZVOdw/WoF9amBkltHnRCrwh9aZPixwES3nEe3MozBgj39iA5TwQgAQaxqww2UNOvFj9zfpX9IFv1ORdftnWQq/aXIQeWTCwR+ID+PGh+F8DYVh",
 														"3": "q+dycETpu0yw6t588qbXhQ1iHbJMYIoTv3ZQRS2191JiIb3jIlp7mTh9a/J4Ed+SGSRiNl1pYz2wVgSeunOg7ilTrWWfhE2YD7Bz5R4ojqn7kGaI8k/NBgbfAeqflo7W",

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_partial_invalid_root_quorum_then_valid_quorum/sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_partial_invalid_root_quorum_then_valid_quorum/sync committee.json
@@ -12,9 +12,6 @@
 														"2": "pIMnG13JIH+83kIsioA98IgyOVJ9Oq71Klbl2HRRbpWVYJnZVXwtcFF/Z+MtYs8xAJRfKd9n0rw0CoBrp2Ehfumf5chA8JV2WXRenzJWaahihh5vPc67Mc5BYE7GzYEp",
 														"3": "lVzSIUi0hK/w+Vp9cuqjOJpi2CUPN13FxHKwvpA9nHPz3b5y4xCVKGk76jdlQdPODQwI5nv4BjtshO2aDuV83R5vouYMHvgy3sE9ouAX/EnZzqrBFxBU8X1IFh4kfTbQ",
 														"4": "rd3NOwo9LigmvywtW8Wj43oP6C12g1/kkNAByOYdqJkmtvuCmgkxssPm1VoLTNX/FDpWYJoDDPI4v9bw8RS4C0WXExfgb/5/1k+vqNz3Zgt5Q2Kz6H7Im3fA/gEHi0XZ"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "ifxlSDBqXziMuDYrqzxTC2en4AYHVvmMgGsbFUAzf/lHJIYNz673bVY37nD+wYtYBGRRuekESqupUFCRJ96X4Av7H0krpyS6gXHswvLbwBmOWbIuR8shJdCdP5g9usNw"
 												}
 										},
 										"10": {
@@ -22,9 +19,6 @@
 														"2": "o6vW4Y0nzGVLpxEk/hRsY7ksjLJcDnZVr237gnIe53Q/Pgt06+yDlf2F8d9vHPkeBck8Q/xKC/tjBiQXXvJwoSEN6MXLnNGgsP3UqDAShVA9CG236n4j0GKJeoMrZa+A",
 														"3": "gYjO2BmHvQzxBPMDl9skWbAh9FDJad3T3ZjwTl8Pi+Pt6CI9dSybaMlKWv/DNu1cAZaMKnACRpjXTwsaX6zJnyztCFgF7gsCEbhj25+omZyaNEjFrLp2JdtePWDvDtbr",
 														"4": "hUB/pJWXi0KjXeaPo4TJNtJShBuGg4vc8gd9tx1zTViQx6hZ2zxj6MQMIjrtsUIiB7HJALk+DwXRRC8NFOrHGZcT098sPNVUX8Mlra5OT26d+ZbNwvhoEjrA7WXg1OFj"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "iHWlxiQVjoSebIs0h60vvxqMTsxvnFNI7SXT/of2iXLeZMtZwWEDHgLZBlB1PaCtFRQtGOyzn0Bp4OwO0XWFeMZ0j3rJrrmPBpOb7eYpySKhv/mBArPcmdDvNGd3TGhM"
 												}
 										},
 										"11": {
@@ -32,9 +26,6 @@
 														"2": "pnDw00vP9eiVmRUmJGTQ6uavMq2ZorKwSAwOhqyD5lwyYeMlXVMzL93kZcu0iemfCw/x0GYXDRQIUcBvbTFu2frIXSRDuW8N8owaqBGZyOm0exB4bXnfDlyC4kPb+d7+",
 														"3": "osp9nKz5rvwmGrE1pNN3ionMVzI+JkhR81ywWl66peR1oRX3ucZsdgHTqrAuSUGgD3M7+WCFUT2eCD5U2/KVfj/vOv6KgI51EpkOO3KiyIbKfqfaNYwk03dqkzc4R8km",
 														"4": "iMN6G0BejpA5x/KhDvCdpM8fWV5Um4BcVvQgXsLIfo7ypDOguLCWB95zLr1GmFxvFowR7hbQT26WkbwqGLPmrTbyvEarm9QSWgknJW9gEooIRUw0lsb0QpTEx2bKKdTF"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "iqUIcHBKm2iYni4qQ7UmUr9x43dzqLje1sExB/IJleyNY1jr8xz5DJPdXkzo3rDHGOA3CqltcrNvXDBACLOAAj6F8QfK6HRl+8kEKcAiuUUH97diYu70ArbR6FTJjCMA"
 												}
 										},
 										"12": {
@@ -42,9 +33,6 @@
 														"2": "gDhZYMUhjdOAdtWI55zlH9fHqF7LvADNGvTiQJFDd0qxVAbXGRQgg6LAEvnWc4qCFVtDZp4l2iaciE+jFsi9kY7Yskkx7RiLPAMpfx3vSU+Wm9iNVA1slAZzsOX1vyLV",
 														"3": "gAdBb3nGJBskNROVkzICvTWbYUs7AAwa3LXoni/l/PYzCOdN/2B78nhVWx0XsNKqDaC3yBbMKsCpTv/KDiYmUWn48KwusgVU84x6gbXSmQd4Po/OTQTfJzq4KzHRGuHF",
 														"4": "sQI464CdV1s2bbYzCJbcIzK8seKt2keOKEmcvpoHU2JGR2dQFkjowv/gv4cUqKOIC67Io22O2KBg3Kx2OlHcHhxsFC6NKobUrhussfrkeqbV7gIEoWHhqRGmcfSWPFyj"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "huT+VfbLb9A842GMK1ypFGzfUTEn9zsRUjKgD7KOGBvDZiETDLazWs5kj5uhLXAHB6LGCRq3BWVmVKy2MFsptkE0wkop6o84DdLBBKEMsFAtBZnOFl1MaJH/Xz1VUkS6"
 												}
 										},
 										"13": {
@@ -52,9 +40,6 @@
 														"2": "i6PpYZQUhQPXMgYL7bITp0en0oIWLso3arWDQUkjxLPr0ViM/dHOexKm6rNQc6HFE+8YyjlVSOhZVUuhLINNkqKhv34i48/gy8JWd6f6Mj4XSC+pMN7CGsAbuNzOTJQC",
 														"3": "qBOKV9mJ+776fcPRgjXd6Oy0DaCNU27nQUg02Ca0OMauUlE1I9dcv1CIGBV9G19ECrsWhvQR5HwPfaAAojWXQTUN2jH4ri8zH85EvM5idoayOn/Uv8k7BtUL9szYhJbO",
 														"4": "sFE0qlgAZvRIL19roEKf+d18BHbR94qKdSVCKsHA3uCjfNfRHXrwPSJensvl24cTECmQF1fj6mmpGww7vkfX9ppij4VmX3K83g/rJIoTIejADiztRgc7RHtcHYtf0xMI"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "tw3MS1yVxbG/MAv3FTynoEFzNhz3qEX9nrtl6bJswy4Wj2ScZ29U3+dgZeKxc1GxEsXO7jG+pk5RLNXSLBa8yd56mcERdBl3mzRS+CuCW5cX0LW2Q5KWbeUjclHMsfyv"
 												}
 										},
 										"14": {
@@ -62,9 +47,6 @@
 														"2": "tr0Wb3faJGKZ1SBNKi8XKOfkrisuTbxAum/fb5Vl13ymQkX1tfVkUHOhH36AtyWcAzYGF35/jMsqoitG0asU+47su9UylzWCQoLq2toc3E8roHeHJG1Tatie7wHWj4kF",
 														"3": "t+rpivqwWurECT4gmixMfw2sMSQl/WNqykhQ3jdpRBuTa2SxHHAnZ8aWHv83LElfCype5fv24UGGruPfANq5cLsirDm0YAstjk6whgL/jZCuV2V+CnUo2zxyUlY81pUr",
 														"4": "oYg6s6PfYwSi21cjHssJCuvfPc4BabTXaqrswwLCw3SOZkW+JzM7Bn9diUQbtk2DDCWfDcZPkNXCR28QK4GZblRFvTZHCygwVF3jB+eGjUjflmAlEk8hsUS+eZYs3F32"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "kBEUHVAmNyigjutVEDd8oSgrvUqmpmYJdFeWlwrPxQvJMMSqtanGbLRKGeC9gleOEJaZmCoCjoG+ek5QDYppJNcxfHm0pUSUhssUb3OMOhfA56XK6MCVg+r/AZJznQKA"
 												}
 										},
 										"15": {
@@ -72,14 +54,10 @@
 														"2": "oxuNV1fA8xXXHh0oL3ETdXTRCu8+r7Z/pokEZVopT3R3UTdJjJEzFKJzBlPxlW36EKMCQ6IoFq8ic/qKbma8ULVPPkJ2MbscJEUzedUIzdXwOVVMy8oHK1lGju+LwEPn",
 														"3": "s3Zd8osB7Awmg8zhveHOGrSyWUZoZRrApywADHKndVCp9SLWMJnckv/OEJx0fonrASphLthpjoF/IXJ/o83czIRQjjstMgAuCcXcNwVGMA7WLLDIrTxaZe+eEB8jawy8",
 														"4": "sOsi07WW6lutVqmr/XlAWmtUnFASEGGp8MxXT5RWkh8SQaO/NVrwnTGDcANHXU5qDPW+neWkqHvyyU8vTc4spR3GwXltHVVb369lwXY483K1ya/nYTFxmRFoOaGz/5Xl"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "j/F6U7v4oepnoCtadtEpPa+QRieKUMkp32RoC55GF+f2l8oYqH1lfoW0pVNiMxfRDWRJkwAtjVmGhY7T+o71ij+ggeB82BFnUWIOdjv/Q0Ur9B2ARBdcn7w/HtvIlKZD"
 												}
 										},
 										"16": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "qHUIlfC6l05XfCOFDm2pJIfZh6Wqc4O9OVGkaJYg4A1OFRYD4ZeEd8SitIVViKCoCVPBohU4hg7lmR38ivimmEfeaQ3ytpR62u5x34mInrDyCxi/cZrHxBl3/DgDZ+fX",
 														"2": "tQaR+u9FMoFlPznyVwh+seNc8M+W10pGeNp5CEN9th08QW+WINQ1mCf4ERAkJH5NAGsJPupObA0DsEQEPV6jZaCHIIGL6gaqIdXVCusOlzfcCbHx/wM3bkAJbF4pYHHG",
 														"3": "le4jr0bf1bJqtH+osJDH8vTBbSoVqNfersk6rDNNOIAEAu0LUesc4KHFUYpCY8VUDAE00KnwYogoa3jHLboB2v12krpOQ4M4/E/eobyhSfyGzvyGR7+mtx8RDUeQAS95",
 														"4": "t6Pcqx85zA+VasZhbSp7Sh/m1vGvkpSOtZZQBSVpC3/YoboTIhAmqSb6ic0t4bn7EyCPcDPJ/uYNdvBOYpxyspFr371CsyDXEHwij8KGXd8+PjQf335WodQCP2y2aj6d"
@@ -87,7 +65,6 @@
 										},
 										"17": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "sB+s1BWGt2T5NJpihTu6DJxvBOT4p+pmRir3Wd0DR0NwSZCDif+CMmZ+MvWeWF+0FRIZs9sOWZVKIOsQNmG24UaAK1TEHZ51reGMK2a6sHFNPMvEdVn5/2/4XzIA1/Gi",
 														"2": "tuxc2xjhHahIqo/vv3bvTGJkl+dGWQXHPjpILXKxdYbnZLB50YQ8h102Vxi6w5/+CUnUmr/Fi0gHYOW0gJ/dOguimvwzGEEZiYJkXP5b7W7zGqBP46iZ9JhCm9V8p42S",
 														"3": "pVGQSFE9EV0GU8IuviMRnwDoS/0Luyx3XpOZffyn3yXm825e2hno3J1N6BJisaEjFfuD4Ud4ID1Eg7u790vtvDVyV2peItT4OfXj2Ja01VdAmzdzcsPom3YoomcVrxPK",
 														"4": "tTi1HpEFuNaYGGOVWuA3E7V/lHskuPg3kTeEXxgCDtgEXWtgp5KEPyTG2aMkuP+KE1krMISLhf+ffrC/QMWgEEkPHURVsSgtx5k7AZNICEic8Cf4cnRi5q8O1AA4qNg7"
@@ -95,7 +72,6 @@
 										},
 										"18": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "pMB0m9YOSkmcqF3QeK1hYYSnSIIyGBLBCggHyNAk7VXyvQrNCfrJP5361fnBHSJgBUN6A3s4QMq0KSEbSDcrtZ+rR1+mIFYGzKAxZS+Up36kDfRlyA5JUq4uib5YZPz/",
 														"2": "mD666+Lqq2Bhjt87aNouTJS15+Ppz3K9OFYaUuKnBJOeig+y3aOp0D3YozEdi5gzC8hEFRkwuse+2qF/4fBLXJcZQfjXdTnY45WKn2pSBTF7Gtx/k0dKueD//Y2Y3zxE",
 														"3": "mDs4lUs05oiEcHnqbb2SjrsaNKnNPfO4sfjcomtuMlq3nT7I2GpkFql7AJeMgBOXDuU5InOwxrU+qrif7IRqKfhQCVC57Kz7Gu6+aFp6LspQ0NkdsiGhk1VZyBLA8h7t",
 														"4": "l5G/JhU7gSuX6n1ZY/Y/PzS5K8rZ7ea3IStw8RjxP4h5BUlpWacK+YIHqTb0NTHsEaF+txpHRV67SxdhiL2KZ0xfkBCbquojDqyNL6+BJZ5jfpRH0zp+pjVvL452buHZ"
@@ -103,7 +79,6 @@
 										},
 										"19": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "lcqfl55x2+hOaXxOSfb+ebKGv5m6vqnYKFeEq6DFQoA6En83nWZpYExJbDHGB+J0FtPv9EUpKDhRrHZkYvvVQKT+QIcjgzihryPw+syrP17UPuatb3p+z+vEtdZ1dQUK",
 														"2": "tqu0aONhB5Vbjc2yeF9UyL8BJfmw0chLVP0UcDnBVM9MUCpm5PWW4sYCpLbjPdOJA3UJyTDoOvnL2Apgb3V6u5IlcUpnknErqPc+hfPF+oUytGixB3zCbiFg59j2ONNf",
 														"3": "qgPawbAbxxxFeiRuzZR2yAscpzVGev4ns7+PsUf49vmWdK4W2m2EqYXzkp5p0Lp+A9kJLPHBPxu7esxnys0776/YddwNcR3LQxvbj5MQbEo1lSe+j07qFl8Fs0OD6lyt",
 														"4": "tfxC6YfOIx6wNVoYxtg1caakIs8cjTbaWsOQla2GokauBCPRzlTne3gmbgFffb8hCXqgTQNCO+mtXB5O1WREg1gGcMoX/fgwvEWLLGYNZV+uTENYQe5vcdLuTD5gcvO9"
@@ -114,14 +89,10 @@
 														"2": "sse4OpX2djZmfWFNXErtS4kUM6mTQRifa2iHnylR/Me/dH52TrUqD3fZK2XZjG5UEGCLBK/yJHLd5xl3LvW1QiCfH+ZZNxa+um6YlR4FKzqTjGUBwYuZKzfY4Erm2KW6",
 														"3": "kFN0zv6kk0yC2eqgtNEQxBi/CgO4wa0oPTIMJU9CrOIzgaBBrUyl9/rDkMQv0FZaCFJhqQQZB/mvvWmuoQP6V4uYGYr0MyQ+rdfLX5KaNuy1HrGdm40HKwvdwjKiFR1Q",
 														"4": "jX9ROhVvkkOZWGTpv+DI8JpLMt9InhdV83m38KnclHe+hEob+dlDsDY5wTB7ahknCPlMnQPudGj5W7XGza9PKE2Q9Yd0jtDTwxHe3Z14fLykdxSeixxhpo6ptzA9JaXN"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "q4PqL74+WjcReYv7KD8iBy+y01H1tNp/M4TrVeGwvADLmADJnINrrfoBX/xyw015BsA4ZtV3PKgpXlgPll4WOSA9OeK7UHO7a/831bih3cC6uN3QKt7TmAodx/Z9YvMP"
 												}
 										},
 										"20": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "oImuJxsGrLnkqiGF1uizyqWpBlUzG3GmNjskWTt/2m0W4EIv1R1pUIXv5YFvyXCUAm3uHv2HkMgrkpRCkcqcfuPAZCHDgUzDLI1U6kM5eDy9kAHxcCq09edwcGXxGCO3",
 														"2": "iugEU0w32LGcpYBVpNvvGMeZqt9T6Ttx+IzPsDqeYZdE2KYDNzRoqVacrbNVbAwACwZGgIB07LrqiuyHKMiLNo/PdjXuqrl7pD/Ma+2zN928AYwHMy1l60XptVFQB4uR",
 														"3": "iqn5rxAr2q4hrhMLjv1a99Mhm44MaFRv/AbAjGSK8sfLX3ElKeeOGD5BFo04aFzvGbugxH3qkbp283sToSuAHjEG4FTXDraphwACHkP95Tcqsus5q3a8Bte550g30pHx",
 														"4": "ufo9wODSlJeQS/71GC0IKNfDBi1LVMnTo/h3Pul6Bd9GniAxx3O4v2NqQVtF0sdgEyV1pq9J++R+MCacIrrm7OQQKqHMaXMozV60yQvvSzYn1qbQ1zNYahU6qcHMzUOI"
@@ -129,7 +100,6 @@
 										},
 										"21": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "gup8i8KXwNtEB43spKOFQOZq3bmkcZtPvjiUUOTX0SZLOO9bddaRscqeondMGjYMFyMvptyp+gjS/NMk9L2LpQZGPtfQ8fBZPNPjtf/EP/prI8UIT8yPeRE2jlTMTYtm",
 														"2": "tTGKCqRa6QNqubTY8qVSXSVX5q7JvRNgV9Z/O1Om/UqnVaeFo/WndMssRJ1BWuwQAtYn4k0L1uHpo6mGMy2AQ9riXdSQ16alQTufXxBVQoWj7OyfBh0MfBma0yhVzT2g",
 														"3": "qoyCP/FhEWGJvVRff7U9K+Mh/wqQl0t8Yx3MoW60KwJ5Ew6Q3vlXwrSmCWclOsESGPTqC6CGepRTu2brDcn0GT7UBofELYY0KgYgzIt31/rzuPCfSBExgMZ60OCdDdhm",
 														"4": "tEj8FKZ+UDKZTjvA6fBJUjdO/NrjdUvvbgLbs8Ftu8ZhxBBrnloePLWEBE/R8k3wC3u7av4oXep8nTdFISj0gV+IB7DMAIbnawAQilKgjGAgdbTuroV+yao7Vpm9wmWr"
@@ -137,7 +107,6 @@
 										},
 										"22": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "pRMLVTei4ygVmeTX76sj+1gJsT+xNxSXdGpY9Bv+KdjEuMUnf0DG6SbXgb6o2eriBuCRik7X1a8zEw36VBL1R2jxUkjTdc6Naamlmw85c9FI653CYbWLHfOrdgCvWiXA",
 														"2": "iSheE12bCf7C8/L5aM1BgsFEe+ksJIuyqMXtg8nYMW1FFw6YHix7JTR93WO8QB0gAhcMpnOF9jGdQB3yCdqkybYd48Re0wBJB1rLT9H+dVwNeIfIshVKnJE/RvCsHK5N",
 														"3": "g1oe2VYKIcXGn5TS1AMungRR2CNP2tglkqUnJrkup2f0aDtNQ2FoMPTZH2xt5Y01E/oV2XGXg3uK9kDC3Ru05pwJMVqNnSOisAgC+SwiiWqWjk24uyBaYcObhSbNS6pL",
 														"4": "k9M5RqX7n/Akgalqmc1RXCOFLHNrLk9jxflghrvuHXZvzrVfo/SASHXWIoGiKxoPFGY24OG5REN5uncYkmyOGb0v2ktX454tlq8+/cksqZzNzpkDgMRVPl8ZHdDL9ZMY"
@@ -145,7 +114,6 @@
 										},
 										"23": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "iebsuS4FbhvS9e/H3TotfX0RYQIZdkpXFhLdnKS0bT3yevysHwa+gwZ0Q+rjS8cKBe5TfMRHzXWkqYOyJXJf34YL1C2PV3ytgVV+BGGdESOGfaAVN6DFKcsMYId1lkDO",
 														"2": "ue+mRzAEBiBnquJLeQRIuGgB/Le5WExQ61mMRksxFDcSjr82ts764Vg2DyfPdPJZFqYRDZ9nPi04OGZ15qkLiTogtoqyX0UkIJmF5/mT3E5bBiUOZUupt6OUajGeuq7n",
 														"3": "sqfHny/Liy8AMgHJzRl/dmzosavw2Hr+wY4o8AzaJOeExLMOoZdGU8tEC0Yt8mzjDaTTThRgBP75WLpfxGW1+OCd98jVaGcm56mrWcYTZKQ1xTzwv5CxuJ3sTf2/4+V0",
 														"4": "rGR0DKbUjd5QA+rmPETrkpyFRvMV9LmPhy/H5YghzQk73/tc0xWP2YiaiCYW1kj0FEVhduxEi51zyMf5v+M36ejrksLXJSWX/0JazFEcA/9DaZPFIGFtzgYZTbrbTEbQ"
@@ -153,7 +121,6 @@
 										},
 										"24": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "sxo9cfXmi+PTkdUbVN54m3XubuuGpe09ts0Qb3PquEYJ8/2VOwNlDq9oetTTga/dE4uTmUlNPEDa8FbkaRX8kqnFr2UmRZCktQRmbWgi5i85tYV4HMTDY9CvKtIR/oaD",
 														"2": "g3ki4t6hU1yLiYr1x0xbWJLk1M5pUvBDwoGXcFvi7McrLa3i5RcWbhWwlUYlWb66Fqj1vduz8TUoHQDlOyN8ZxJ63lXFUAdOW06n0A22o8y6k3wfS6tYQEUpMUFn+c7o",
 														"3": "o6Td/NAVo3NNeEe7v2TfTNeVaPajINunlkY9Ov4r/FAEr0xucopQUF44dSsDigq3AWPcB+eb0apA0C5NlYtcf7GLCqNjDRGGx6aYpoOGi/mHKtdvkdRjeFtIIvQJeHuR",
 														"4": "pGlEKfyZXE8ciCdKCUuzHmNCAegGCX2Tyb5hejLWgYCY9uvSBpxalAGYfjl55VpqETecHX3xCaPsGEgL5W20V1R71kpWl9z9QF7i8HAxG1QjKCqfdFbUn4OVDMCR/RWe"
@@ -161,7 +128,6 @@
 										},
 										"25": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "hcJwWj6N76HC1Uo4ba2RjLXFLRtlZ5Fu5UAhMeExkJw4C+DNl1RUTkOTgSdw06CdB7WmFeW7MORWVG4lvCnJ6b6vx5o2zb0aInXSIt/PnAtbvyDfEmCYfcKEkgAsDdwN",
 														"2": "uIePjmjpUifSH3jf8ay7pvlsYzNjnsIxptMgtN+ERmdz7MLHxZ/HrSDURLxu8jUDBojyNY091cRvMV1P4pKwXepUUVozOEdKHUi0xW3TqRIhCJh2xylfK87254ARBwfb",
 														"3": "k7Nt78Kf78XT1ct8/Hcy5BLC0VKMjgniuZ3vI72i2ER9Aap6nQaLMGI1Aeyb7domEoKle7z5GGnQpKeEJiSMVUsPTMVqTzhVF35GsJX68+pCJtLLudem3d05vEDaA28f",
 														"4": "hSbS+b04J8DXUymBhwefE4TpomwzlK0p7Szh/iaFj5XLaWcVuKopVFc7tBFhYw4XAHxrv+xtYGvdIRHuMK8bOPMZYS+4tlSIysgGsJTJGHzng1cb8oySG4UtfSLskT7z"
@@ -169,7 +135,6 @@
 										},
 										"26": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "p9jcs3kG8XR/v3bI9qAnejnpAF+zPv+Qgh4TXfraBYj/0ygWR/GTKqqf2pdSVaPMBghbDPl5ogV9gcR3e4BYk6QM5GRCdHXkq7ZEEwmUEnq5Wl7Gj+K1ngqVZ6X6vY/I",
 														"2": "grIxwzjvmbUs9Bb+b6fPmBWCgjDwD+b2ijTqn5xmsosveyGL/IQ1C3tTjXhVUx0JA9zp6cuYBaxCZM1z2dU3gXUjUrHrv6RsEQrja21A+lsXAfv0vegpZXkyKjQ0a3sI",
 														"3": "sV0wYhS5EVcmYSdnEn/io5tgSiswY9HjkUKkYBzT4MJqhZGxy6Q6o8fuj0fqr6vsFa/ZT/N0pPbrNGi99axDfom2Wdxo4CSwMs0y6ymIT1CEO+zQeBdwE5+rtO3jvg/2",
 														"4": "jSRpz1NkVnW/1i+0PYU/kUrz61IvfcCqIdQ6pKqgkHetZ1ADMuP5JDLRUT0Ck4n6At0/gcVuuQ3UlPC23M51ppIMkpQlBQgEdDlk32E+akTSec9c/KAmBtxZ6TiWk7kM"
@@ -177,7 +142,6 @@
 										},
 										"27": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "mVO6ubOOg/2UZjO4mLkWEyA6sMMvzE1p4mC0mxx3ikgXYCG52tp7mO3dQsX9EcYQGeVCj+kS77TJ55g2CAhcoqN6obMmvxq/PuSZ8eMI7iZ2ZhdgC89dx/jGoZuh+Tbu",
 														"2": "qYfpHfR3l0mn1LllJHfANPObxHV+aJKmVwZEC3WjN43pA+CmTtkdmuiLfIFlCdf9FK+9cwaHJmip9QLeoTdTHD69H7lh0670G6CheknT1ljsNc4OD3yTeeQIayC6WQhj",
 														"3": "iCRSPDfrz5D7SQJOG76oyEnXmEZRdZR+peCVJBrF30xhMQ0BGA1NibyKXG019bn6DkcLheEbBKW0+J7jIYksPjLnLuhBKVV/xuooTEukXQ55EWzDu0EOpMjGh09Inxsq",
 														"4": "guR17UkMl8LNyzoRP6i6j7CfrkG3P3++2S2BryhMjJHZBb6Xw84wQHnxVl4POdl/DsdfOjz+fXSYn4t2Jzv/JEqLMp6urYoJ1uuqRxk+7a4nVWwyYKOqREGsOc2KDnAL"
@@ -185,7 +149,6 @@
 										},
 										"28": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "sQtHz8RaOS83+AfZxKWLLSDg4S9kXDSWhXv8W7oX90Sms9659z6VEBrS05akYvtnAIaj0NlXBXtFgH3EeY12+V+ZAspVi/jPsHzpN1UuDYCRSAXuw5irxlZYAkCJB0/H",
 														"2": "gml/xGxpWAnASU1skjp3HqFzRh8zfiYTll/roOKV5KttrqGWECx3gSAlZ/kvqlVBBTavUtPqTCfyLMQSASgboAhIjks8YTKdcaW8EqpdJz62qXmET0g7f3VbacX6qnUc",
 														"3": "uTxNacsy6/nmckH6o6oqhan5+pRzfD7S0koAzHJNp4mr2BSlmy/Wfs0ZBiR42tpEFPMezVj7A4C2bqcf/8L2TN4JoumGGj5HTNKbrhN0R5HeHqBjgYaoG/ErqhrlGnl5",
 														"4": "hfmlIFAg2rQRg2a9V9hcDRy5dsID6IX/OF6t9+g8SwSK7zE/yu+dx/7zPsvT0dpGDBWq9X20vgqshklybO0L8iEDfVl1F5sJGZckqb7tDuI4t658fqr5deFO2sE2wGpa"
@@ -193,7 +156,6 @@
 										},
 										"29": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "tPBE6+mCW5QKfdB5claeCj4DQ8pEM7ShPBKupfuMJC27sjTRzplISKNlkQS2AQ7cBPDt4cc9eCuyQZaO80Ok0hsVYyWlEH60IBU0RJ/yMYn781rt8qylFdpSHB8n+Bjl",
 														"2": "rv+uGWnHZJXrHC5UZta4q8DQhrdufxsufd+QDkOjxap93de3+Yys05UHQuzoO10uEA8xnDq47uJwuIQJ20ayzIUUIGeWrKRVGaqw3/x+bu9EH5dKR1cqLubJ3IAHKtLM",
 														"3": "lYH7ogo+W1BmnUBhDmWiHXWLD61SdYskCO3/GGzUUs6hBiy3ltcB4lAHxSijQqI0EleXnu2t/VP91oYPIw8jU0ErCZF08E7zV8MFwIw1uEwKUrcBe431GQmeJiZ9s5Me",
 														"4": "p6MHMkTWCgm5niqc4Ral++HPMqF17QgZwaDuDh27DVi7NQGyGg5QekiG46iXGdItBl/3+xpFFlWgL1buBLww5BSJYU3HWED6llerqQlgBHcrrKBkF4kYpAaEgzIFLwZ/"
@@ -204,14 +166,10 @@
 														"2": "ksd1CkWlubMFSRVed5VvcHFj07+T/EiEm8j6++Rp66o2az4M5pHQB8VBykw88yNkCfsQyz50IIQ9NiDvFYsWypItSxXC7zL3iNGxuv4bRRD1YvxhvSL5AOuKl7Ql974O",
 														"3": "oyIcr2S+Bc1wNiRG0f2kphYWUmGL6fDfgV9fffsr8iuqWGqMSB+OImu8wmPoTbwtCJ9be1pp4M7tYz6IfJYsj+2N/8gy/4cNl0ggN4rVf6N2pRYY65jmNlbxoWbfeZJQ",
 														"4": "pItaOg6r2zdBudc4kn77ERRRxb0l+eM6cZosEXUjR6F1DobfkiGv9RBNFVysI5wQDthcgNtMAcmV1iKmmjvkQasabIELCHY1YAorHciYQSeqEV235F+KKYG7tKZwAOTA"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "jVp1aEm9YJuYChNa70FnAOx1F6aXxic28oRWZt65THxMZU9AXpx6AGAeobLdcy03EAGXXjCYLEdUFAYXlafZmOFyxC2bpPVfRNvaaKaUFa9DzMkQxjI3KZjqBPRY2A2M"
 												}
 										},
 										"30": {
 												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "huTXfQMFljq5qlWEHYUK+cax2IN4PvMfhBjYiJMHjaTr/vbVhYiKWalWpVWJ8t+7CBV1im0Gi5f1IwLKJZeG8W6bdhEJmG/DRtl9IuMPXYd/DMATg8t87MGCMJXGB8Fh",
 														"2": "hpGOkn1oqQHu8cvP60AlPkC0aUSu0MWQWKV8dmOIKzWeh4YXEcXGaqXwUBKgd5r2EX0IZfSQxmAoUBdIzMigWKG0dOA/rsGSq5U6yR2nYLnsV8BWfcs9Pu/QJbor2Tpk",
 														"3": "qsmLmEnu4+I6jvP/BRuGZ2/Hh87o3nIrhzeZq1dksoec+KTXz9pr2UxiOhU4j0wLCxlf2vIc/W1C+qRA5HVKaP/HD2gmgsG0bzOVIjSpM65GFXy/d2OFZ7cwWfs/dq26",
 														"4": "mM2b/Wm06ZTObZ09OINYJ8jyJQOlWMIWr714tIvGwIGgu/aXV+lrZMx38mCV7pmvCm7OXCufJJyDW39oGCgFKR9iMTQmRRwQwG19miBTFCfKXuKrZ3kuhSNWxtbHs07l"
@@ -222,9 +180,6 @@
 														"2": "jbWeTv0KFHqGy+PDOz+0NLc+i0pHEGYUnNZC3Ub+0L6SGD5fvU7Bw9B9v7SxEc9LAYtc3ABJIF/5V9r6NUj+znXzFgoBdV8YwCmPbt2yVnci6ZmAJCoDdnUsyXWrXyHE",
 														"3": "qlhMg1aGvj1woZw2PGP3GSfi6WPOZbJgwbbSYFdpNcvMoJLSxD0njvxuGFfuJNVkF6PF7FfCi8J5oI7GPr8qwmPwxbhgtvfejiU6FPXwRHvbG1L/db6Aci0k3DeBYF/H",
 														"4": "owraaSV8E4IJvOoWwM3qxSO0ammiOPlVFDtXaYyE1koj9optUv+2XyOmuFQyhRq7FuIUmj29kTFIYYjUlE0su3yZ3ZZzCEKaA27yiX7uUX5u1Nq5BhfFW5S9VeuG/0RT"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "pYFcuRc+gEKJ3CUgPN4PGwTeMxztgu5HxuhjjgqkwIlrHUeO+gknkS+m11xf1foYDa4nqQzUKoITdzDgGbE0KYGVaTY2WqrZh/I1L6dnEiqlPH94gkaoSu0hDrNPTnGt"
 												}
 										},
 										"5": {
@@ -232,9 +187,6 @@
 														"2": "peJ0segFMmHUhwN5RWO95aA2ONZbD2e1u3JryOIJKhXUnwxs/+ZZFzz1yoA3ZcToGSzulYZBOTJOZybDN6rT31d0x1rHHP/YRHy+EUWY+bCOg95z2kWxQNgbJLSfcjF2",
 														"3": "k1FuqDaEttBZpKMYLOmwC8+ig0NCkdDKVMVcFt0N0IbyzMogcFeB+9nyLo77F0GaDFh00Ts1iug3l2HTkPi2BU5ZQCs3mgP689FZ3UxNNJBNMEm8Zqq7PHHcy6YX+qGx",
 														"4": "uEw+TM7J58tQUkmRQlmaCAg1Hbci+hJwb3mQAf69GCGNZNcrQeoY9HezHTPmjxywEfUMz3p8qOZQcw0nuK+6RI9S8Y1V8D13odLAw7gqF1U9FTqz0L0GYbUlEM8/JvqE"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "js9ejDO1281NH869+uCt/fsrybUsN8vegWBzqF1snfZWtPNl8nxikPEtj8M6SqCgFMQEDLZp3qeZy1r0Oo8RFT8qsBaWag6o/yAQDvsJDycmCFzR/28D6ncmx7WekOPe"
 												}
 										},
 										"6": {
@@ -242,9 +194,6 @@
 														"2": "sc0tdHkKJ1TAPL86SRtljM0p/Hyze0sVB6QjqjjeYhSCdxia8vVhwXkZU3jh48OUCPdgD6cIA8CmBVE0jcEB7UyPlibO+l8o9sxhAjI0LeoxYB3TTWCtamkqagHXimi1",
 														"3": "rgbWp2EWoZ/6fztXH4/XNWRxDxs+a3j8lFkGcwAdM5xfF2d8iSxpMVv1ZGSzcKPxAWV1CQ6CvmueckJWYtn0rAHUB9FnGE4ft1F+O/tbzAFWxfiNQ8eN9G9AR6R6b+x+",
 														"4": "rQcRqctPjYgNd26jSsv4zzww0fBsYzOJevvpv/i3/O3yVohDnEeVk4bM+0ZRs+QOD5SSje3YWkLldHETOAyGZhiTRXv321/YdhZDtfdIviJj6DKvXkhhXStJ8PkDcBN4"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "hb44PZSzGkCc7GGQRyCJxP9LYdiHqqZ5au6jfDm9TmctuGNxI09s6Uxx6dwymQp5GPDJZJZo4uqUUM2rDCrgpLf3ktZbRHjDWGmnJSwm2BEcv9cGrbO2QVpOdNBr88ul"
 												}
 										},
 										"7": {
@@ -252,9 +201,6 @@
 														"2": "pXUUzBeQUNfvhlMGrCyK5NL1Z6MAKMwf/3XBT+j2qkOjbHBMe8JNLQWH7XC0gRPqAHnXpXUT9jHRLyny1hkFLLTtoCi3xJu9/SxbQntUQKQO+Ztk8/cEb+s2fxpninFI",
 														"3": "ubXuAMGWb3apwbh593J0G3KgAu8kSfKTyWC/hDxKvN6L/PZ3nHtm2qD96MF9h/9ZAOk1+olC8am/0EasZjh51VloNnfWmYR8o3RlWuqoBMvVXEky6xVqm+x3vP7NQYrs",
 														"4": "heXqR1uj+hp2aeXVng3MyGraq938otx+3oIDfNQELSJ02O9zl5ixqG60NMKHp6tRD4tNs+gU8JKrsyGCUNrPGM+9xE7j8bQyEJTsZ1Umqqj/ClCpe5O6EMyQN9tG1axx"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "knRWV+8ECdTmmmi6BpykOdWyDe0ueErACD96t7XAk1F6zKiSCkeDj0nPbOA1ggYdCL1RHEswHtYYU5mkNlaN0Gse0oD82VYDDhLrYB3T7mqghjdnHYGZY2gLzCIxm/1i"
 												}
 										},
 										"8": {
@@ -262,9 +208,6 @@
 														"2": "oyxt9UoH+FBV1+fS0G6QUV6UQLEfiYvNcKykuCjqE8dK6vl/B29cAyZtKk6/lIk8FhDL3LpP6KRtqYQdzr+mai3yPfEJSdFHKxn60fCAX9vIleRLMOb0qgG7yflw/zGf",
 														"3": "r+TK5JOUkUIy+p+g/oajYt3hc6ka+8V9iIbuNkGshZI7UgwnpwEAwPDJK62Qr4x9Eued2FZNrYLAV5tD4O+vuX7QZCHGWfn9bkFvRxzsC4E3Ysi5INgFrLwl7aKPv7qF",
 														"4": "q1TY0btSXENpFBkWnZy1/opYuON9BKnC38zteNlOT8kc/fhWjUG6ydlvUuCG6yqNF4BtFQgA3q7JavStKEKy7C3m8Oa8OlT51XlAo23wdNYq8FoT/OjPlWsK1Va3HSzk"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "sTWJgj5pcQtR5tm5OOH+Y4uaUpME6NYhckAz0Kc4Hbcro7aQl9bRHni1PqaqX47xAg4ANXmj6b54+WrUU0HcPCu1gZfFssQHft+Fu/clv63LHdAOXKYSwT3Nmrd+PHxj"
 												}
 										},
 										"9": {
@@ -272,9 +215,6 @@
 														"2": "ihXYnKSsyKO6YPedHHWLrOUlTPn2Ys7+lXGK/K4ORwoAgAgi1XF+EOPPFgcy9Q12DhwgAc/99I3/You1lgSsCUMDOMueV5mh982UttZ+R+3x9c7g7YPfeSJ25rgrPCLt",
 														"3": "jMjonsK7YSLJhO9JLZf9fIb/Uz2Ladrsl4iuD/UYK7cSXSNblZl2cXYI40MfGlBeCsE0N+ZQhcmBNLVZgbpFQERnaV5eB6i2S6GtrkujN7FjmVs8eEaPGxXa+1vGLFPF",
 														"4": "t96BHBI4og8RYeAEwF8dbFPkxejW5oJJIyBeX2fTbvV9fu2e94Ym3R1AB8ofL9E/CtkAnmaiL0Wpj/uEAHkXg5kNxATcn+FNQmehiKHxxpPkmEGZsz/dEdKjkv48BR2U"
-												},
-												"b04d4c832e3acfce1bdc8bd79b1ebf5a5b6f3cb4fc8041f4e0769e427b10fed6": {
-														"1": "smyCwv3zWMqQeEUWMc+8FGin7BHS0ZnbGB0wRar+bjDA1UsN7TipHpsf++LbtCSdBRBanS4K+2wZdTmHdarBe3MCPtC4Nw0t1tUO+GDKt6obSuKPOiMbX8S8uxaYrSpl"
 												}
 										}
 								},

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_too_many_roots/attester and sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_too_many_roots/attester and sync committee.json
@@ -6,16 +6,7 @@
 								"Quorum": 3
 						},
 						"PostConsensusContainer": {
-								"Signatures": {
-										"1": {
-												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt"
-												},
-												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6"
-												}
-										}
-								},
+								"Signatures": {},
 								"Quorum": 3
 						},
 						"RunningInstance": {

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_too_many_roots/attester.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_too_many_roots/attester.json
@@ -6,13 +6,7 @@
 								"Quorum": 3
 						},
 						"PostConsensusContainer": {
-								"Signatures": {
-										"1": {
-												"4ae32f48079745930bc24da670a6fe72052e13e3832728c6aa2580adc0307b83": {
-														"1": "iU3PPG+KB+22Rz9ypL5hfg0kr6EuyvsUfyT4yiA5GaQmSuT2Q8z+NSRY8HljYoz2GFhYqJef2QekHSie73s4Ygn6jPp2Rf5ISQ/JHpbUTORk/oOdEPZPGBUc/yCeNTrt"
-												}
-										}
-								},
+								"Signatures": {},
 								"Quorum": 3
 						},
 						"RunningInstance": {

--- a/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_too_many_roots/sync committee.json
+++ b/ssv/spectest/generate/state_comparison/tests_MultiMsgProcessingSpecTest/post_consensus_too_many_roots/sync committee.json
@@ -6,13 +6,7 @@
 								"Quorum": 3
 						},
 						"PostConsensusContainer": {
-								"Signatures": {
-										"1": {
-												"85794142e7b2a4c66a79a68377705fb95f84197a4d2ca354d3b72580a0b7529e": {
-														"1": "pyyG8N2IyWA8Ffzt+ZQnWI0FaaxLlyaYuyA9tgVDWRMBuRCGomjtnAKMlbYIXRx6DyaAsNFkT8yZcVtBR0QYMiBUCnOFAAOLUznXS16y5R1kGwJ0TpIfvlcym3M/QqX6"
-												}
-										}
-								},
+								"Signatures": {},
 								"Quorum": 3
 						},
 						"RunningInstance": {

--- a/ssv/spectest/tests/runner/postconsensus/duplicate_msg_diff_root_then_quorum.go
+++ b/ssv/spectest/tests/runner/postconsensus/duplicate_msg_diff_root_then_quorum.go
@@ -39,7 +39,7 @@ func DuplicateMsgDifferentRootsThenQuorum() tests.SpecTest {
 					testingutils.GetSSZRootNoError(testingutils.TestingSignedAttestation(ks)),
 				},
 				DontStartDuty: true,
-				// No error is expected for this duty because it don't overwrite (in state) the previous message
+				ExpectedError: expectedError,
 			},
 			{
 				Name: "sync committee",
@@ -60,7 +60,7 @@ func DuplicateMsgDifferentRootsThenQuorum() tests.SpecTest {
 					testingutils.GetSSZRootNoError(testingutils.TestingSignedSyncCommitteeBlockRoot(ks)),
 				},
 				DontStartDuty: true,
-				// No error is expected for this duty because it don't overwrite (in state) the previous message
+				ExpectedError: expectedError,
 			},
 			{
 				Name: "attester and sync committee",
@@ -82,7 +82,7 @@ func DuplicateMsgDifferentRootsThenQuorum() tests.SpecTest {
 					testingutils.GetSSZRootNoError(testingutils.TestingSignedSyncCommitteeBlockRoot(ks)),
 				},
 				DontStartDuty: true,
-				// No error is expected for this duty because it don't overwrite (in state) the previous message
+				ExpectedError: expectedError,
 			},
 			{
 				Name: "sync committee contribution",

--- a/ssv/spectest/tests/runner/postconsensus/duplicate_msg_different_roots.go
+++ b/ssv/spectest/tests/runner/postconsensus/duplicate_msg_different_roots.go
@@ -34,6 +34,7 @@ func DuplicateMsgDifferentRoots() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "sync committee",
@@ -50,6 +51,7 @@ func DuplicateMsgDifferentRoots() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "attester and sync committee",
@@ -66,6 +68,7 @@ func DuplicateMsgDifferentRoots() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "sync committee contribution",

--- a/ssv/spectest/tests/runner/postconsensus/invalid_expected_root.go
+++ b/ssv/spectest/tests/runner/postconsensus/invalid_expected_root.go
@@ -30,7 +30,7 @@ func InvalidExpectedRoot() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
-				// No error for this committee duty
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "sync committee",
@@ -46,7 +46,7 @@ func InvalidExpectedRoot() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
-				// No error for this committee duty
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "attester and sync committee",
@@ -62,7 +62,7 @@ func InvalidExpectedRoot() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
-				// No error for this committee duty
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "sync committee contribution",

--- a/ssv/spectest/tests/runner/postconsensus/invalid_then_quorum.go
+++ b/ssv/spectest/tests/runner/postconsensus/invalid_then_quorum.go
@@ -26,7 +26,7 @@ func InvalidThenQuorum() tests.SpecTest {
 				),
 				Duty: testingutils.TestingAttesterDuty,
 				Messages: []*types.SignedSSVMessage{
-					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusWrongAttestationMsg(ks.Shares[1], 1, testingutils.TestingDutySlot))),
+					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusWrongSigAttestationMsg(ks.Shares[1], 1, testingutils.TestingDutySlot))),
 
 					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusAttestationMsg(ks.Shares[1], 1, testingutils.TestingDutySlot))),
 					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusAttestationMsg(ks.Shares[2], 2, testingutils.TestingDutySlot))),
@@ -47,7 +47,7 @@ func InvalidThenQuorum() tests.SpecTest {
 				),
 				Duty: testingutils.TestingSyncCommitteeDuty,
 				Messages: []*types.SignedSSVMessage{
-					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusWrongSyncCommitteeMsg(ks.Shares[1], 1))),
+					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusWrongSigSyncCommitteeMsg(ks.Shares[1], 1))),
 
 					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusSyncCommitteeMsg(ks.Shares[1], 1))),
 					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusSyncCommitteeMsg(ks.Shares[2], 2))),
@@ -68,7 +68,7 @@ func InvalidThenQuorum() tests.SpecTest {
 				),
 				Duty: testingutils.TestingAttesterAndSyncCommitteeDuties,
 				Messages: []*types.SignedSSVMessage{
-					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusWrongAttestationAndSyncCommitteeMsg(ks.Shares[1], 1, testingutils.TestingDutySlot))),
+					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusWrongSigAttestationAndSyncCommitteeMsg(ks.Shares[1], 1, testingutils.TestingDutySlot))),
 
 					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusAttestationAndSyncCommitteeMsg(ks.Shares[1], 1, testingutils.TestingDutySlot))),
 					testingutils.SignPartialSigSSVMessage(ks, testingutils.SSVMsgCommittee(ks, nil, testingutils.PostConsensusAttestationAndSyncCommitteeMsg(ks.Shares[2], 2, testingutils.TestingDutySlot))),

--- a/ssv/spectest/tests/runner/postconsensus/partial_invalid_root_quorum_then_valid_quorum.go
+++ b/ssv/spectest/tests/runner/postconsensus/partial_invalid_root_quorum_then_valid_quorum.go
@@ -16,6 +16,8 @@ func PartialInvalidRootQuorumThenValidQuorum() tests.SpecTest {
 	ksMap := testingutils.KeySetMapForValidators(numValidators)
 	shareMap := testingutils.ShareMapFromKeySetMap(ksMap)
 
+	expectedError := "failed processing post consensus message: invalid post-consensus message: wrong signing root"
+
 	multiSpecTest := &tests.MultiMsgProcessingSpecTest{
 		Name: "post consensus partial invalid root quorum then valid quorum",
 		Tests: []*tests.MsgProcessingSpecTest{
@@ -37,6 +39,7 @@ func PartialInvalidRootQuorumThenValidQuorum() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: testingutils.TestingSignedAttestationSSZRootForKeyMap(ksMap),
 				DontStartDuty:          true,
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "sync committee",
@@ -56,6 +59,7 @@ func PartialInvalidRootQuorumThenValidQuorum() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: testingutils.TestingSignedSyncCommitteeBlockRootSSZRootForKeyMap(ksMap),
 				DontStartDuty:          true,
+				ExpectedError:          expectedError,
 			},
 			{
 				Name: "attester and sync committee",
@@ -77,6 +81,7 @@ func PartialInvalidRootQuorumThenValidQuorum() tests.SpecTest {
 					testingutils.TestingSignedAttestationSSZRootForKeyMap(ksMap),
 					testingutils.TestingSignedSyncCommitteeBlockRootSSZRootForKeyMap(ksMap)...),
 				DontStartDuty: true,
+				ExpectedError: expectedError,
 			},
 		},
 	}

--- a/ssv/spectest/tests/runner/postconsensus/too_many_roots.go
+++ b/ssv/spectest/tests/runner/postconsensus/too_many_roots.go
@@ -30,7 +30,7 @@ func TooManyRoots() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
-				// No error for this runner type
+				ExpectedError:          err,
 			},
 			{
 				Name: "sync committee",
@@ -46,7 +46,7 @@ func TooManyRoots() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
-				// No error for this runner type
+				ExpectedError:          err,
 			},
 			{
 				Name: "attester and sync committee",
@@ -62,7 +62,7 @@ func TooManyRoots() tests.SpecTest {
 				OutputMessages:         []*types.PartialSignatureMessages{},
 				BeaconBroadcastedRoots: []string{},
 				DontStartDuty:          true,
-				// No error for this runner type
+				ExpectedError:          err,
 			},
 			{
 				Name: "sync committee contribution",

--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -105,20 +105,20 @@ func (r *ValidatorRegistrationRunner) ProcessPostConsensus(signedMsg *types.Part
 	return errors.New("no post consensus phase for validator registration")
 }
 
-func (r *ValidatorRegistrationRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
+func (r *ValidatorRegistrationRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
 	if r.BaseRunner.State == nil || r.BaseRunner.State.StartingDuty == nil {
-		return nil, types.DomainError, errors.New("no running duty to compute preconsensus roots and domain")
+		return nil, []phase0.DomainType{}, errors.New("no running duty to compute preconsensus roots and domain")
 	}
 	vr, err := r.calculateValidatorRegistration(r.BaseRunner.State.StartingDuty)
 	if err != nil {
-		return nil, types.DomainError, errors.Wrap(err, "could not calculate validator registration")
+		return nil, []phase0.DomainType{}, errors.Wrap(err, "could not calculate validator registration")
 	}
-	return []ssz.HashRoot{vr}, types.DomainApplicationBuilder, nil
+	return []ssz.HashRoot{vr}, []phase0.DomainType{types.DomainApplicationBuilder}, nil
 }
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
-func (r *ValidatorRegistrationRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	return nil, [4]byte{}, errors.New("no post consensus roots for validator registration")
+func (r *ValidatorRegistrationRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
+	return nil, []phase0.DomainType{}, errors.New("no post consensus roots for validator registration")
 }
 
 func (r *ValidatorRegistrationRunner) executeDuty(duty types.Duty) error {

--- a/ssv/voluntary_exit.go
+++ b/ssv/voluntary_exit.go
@@ -104,17 +104,17 @@ func (r *VoluntaryExitRunner) ProcessPostConsensus(signedMsg *types.PartialSigna
 	return errors.New("no post consensus phase for voluntary exit")
 }
 
-func (r *VoluntaryExitRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
+func (r *VoluntaryExitRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
 	vr, err := r.calculateVoluntaryExit()
 	if err != nil {
-		return nil, types.DomainError, errors.Wrap(err, "could not calculate voluntary exit")
+		return nil, []phase0.DomainType{}, errors.Wrap(err, "could not calculate voluntary exit")
 	}
-	return []ssz.HashRoot{vr}, types.DomainVoluntaryExit, nil
+	return []ssz.HashRoot{vr}, []phase0.DomainType{types.DomainVoluntaryExit}, nil
 }
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
-func (r *VoluntaryExitRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	return nil, [4]byte{}, errors.New("no post consensus roots for voluntary exit")
+func (r *VoluntaryExitRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, []phase0.DomainType, error) {
+	return nil, []phase0.DomainType{}, errors.New("no post consensus roots for voluntary exit")
 }
 
 // Validator voluntary exit duty doesn't need consensus nor post-consensus.

--- a/types/testingutils/beacon_node.go
+++ b/types/testingutils/beacon_node.go
@@ -85,7 +85,7 @@ var TestWrongBeaconVote = types.BeaconVote{
 
 var TestingAttestationData = &phase0.AttestationData{
 	Slot:            TestingDutySlot,
-	Index:           3,
+	Index:           TestingCommitteeIndex,
 	BeaconBlockRoot: TestingBlockRoot,
 	Source: &phase0.Checkpoint{
 		Epoch: 0,


### PR DESCRIPTION
This PR adds a validation on the number of signing roots (and their content) for the CommitteeRunner and aligns the existing tests with the new error.