### PR TITLE
Remove convenience functions

### DIFF
--- a/p2p/validation/msg_validation.go
+++ b/p2p/validation/msg_validation.go
@@ -106,7 +106,7 @@ func validateFutureMsg(
 		return errors.Wrap(err, "invalid decided msg")
 	}
 
-	if len(msg.GetOperatorIDs()) != 1 {
+	if len(msg.OperatorIDs) != 1 {
 		return errors.New("allows 1 signer")
 	}
 

--- a/qbft/commit.go
+++ b/qbft/commit.go
@@ -149,7 +149,7 @@ func validateCommit(
 		return err
 	}
 
-	if len(signedCommit.GetOperatorIDs()) != 1 {
+	if len(signedCommit.OperatorIDs) != 1 {
 		return errors.New("msg allows 1 signer")
 	}
 

--- a/qbft/decided.go
+++ b/qbft/decided.go
@@ -47,7 +47,7 @@ func (c *Controller) UponDecided(signedMsg *types.SignedSSVMessage) (*types.Sign
 		inst.State.DecidedValue = signedMsg.FullData
 	} else { // decide previously, add if has more signers
 		signers, _ := inst.State.CommitContainer.LongestUniqueSignersForRoundAndRoot(msg.Round, msg.Root)
-		if len(signedMsg.GetOperatorIDs()) > len(signers) {
+		if len(signedMsg.OperatorIDs) > len(signers) {
 			err := inst.State.CommitContainer.AddMsg(signedMsg)
 			if err != nil {
 				return nil, err
@@ -116,5 +116,5 @@ func IsDecidedMsg(share *types.CommitteeMember, signedDecided *types.SignedSSVMe
 		return false, err
 	}
 
-	return share.HasQuorum(len(signedDecided.GetOperatorIDs())) && msg.MsgType == CommitMsgType, nil
+	return share.HasQuorum(len(signedDecided.OperatorIDs)) && msg.MsgType == CommitMsgType, nil
 }

--- a/qbft/message_container.go
+++ b/qbft/message_container.go
@@ -79,7 +79,7 @@ func (c *MsgContainer) LongestUniqueSignersForRoundAndRoot(round Round, root [32
 		currentSigners := make([]types.OperatorID, 0)
 		currentMsgs := make([]*types.SignedSSVMessage, 0)
 		currentMsgs = append(currentMsgs, signedMsg)
-		currentSigners = append(currentSigners, signedMsg.GetOperatorIDs()...)
+		currentSigners = append(currentSigners, signedMsg.OperatorIDs...)
 		for j := i + 1; j < len(c.Msgs[round]); j++ {
 			signedMsg2 := c.Msgs[round][j]
 
@@ -94,7 +94,7 @@ func (c *MsgContainer) LongestUniqueSignersForRoundAndRoot(round Round, root [32
 
 			if !signedMsg2.CommonSigners(currentSigners) {
 				currentMsgs = append(currentMsgs, signedMsg2)
-				currentSigners = append(currentSigners, signedMsg2.GetOperatorIDs()...)
+				currentSigners = append(currentSigners, signedMsg2.OperatorIDs...)
 			}
 		}
 
@@ -120,7 +120,7 @@ func (c *MsgContainer) AddFirstMsgForSignerAndRound(signedMsg *types.SignedSSVMe
 	}
 
 	for _, existingMsg := range c.Msgs[msg.Round] {
-		if existingMsg.MatchedSigners(signedMsg.GetOperatorIDs()) {
+		if existingMsg.MatchedSigners(signedMsg.OperatorIDs) {
 			return false, nil
 		}
 	}

--- a/qbft/messages.go
+++ b/qbft/messages.go
@@ -17,7 +17,7 @@ func HashDataRoot(data []byte) ([32]byte, error) {
 func HasQuorum(share *types.CommitteeMember, msgs []*types.SignedSSVMessage) bool {
 	uniqueSigners := make(map[types.OperatorID]bool)
 	for _, msg := range msgs {
-		for _, signer := range msg.GetOperatorIDs() {
+		for _, signer := range msg.OperatorIDs {
 			uniqueSigners[signer] = true
 		}
 	}
@@ -28,7 +28,7 @@ func HasQuorum(share *types.CommitteeMember, msgs []*types.SignedSSVMessage) boo
 func HasPartialQuorum(share *types.CommitteeMember, msgs []*types.SignedSSVMessage) bool {
 	uniqueSigners := make(map[types.OperatorID]bool)
 	for _, msg := range msgs {
-		for _, signer := range msg.GetOperatorIDs() {
+		for _, signer := range msg.OperatorIDs {
 			uniqueSigners[signer] = true
 		}
 	}

--- a/qbft/messages.go
+++ b/qbft/messages.go
@@ -153,9 +153,16 @@ func Sign(msg *Message, operatorID types.OperatorID, operatorSigner types.Operat
 		Data:    byts,
 	}
 
-	signedSSVMessage, err := types.SSVMessageToSignedSSVMessage(ssvMsg, operatorID, operatorSigner.SignSSVMessage)
+	sig, err := operatorSigner.SignSSVMessage(ssvMsg)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create SignedSSVMessage from SSVMessage")
+		return nil, errors.Wrap(err, "could not sign SSVMessage")
 	}
+
+	signedSSVMessage := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{operatorID},
+		SSVMessage:  ssvMsg,
+	}
+
 	return signedSSVMessage, nil
 }

--- a/qbft/prepare.go
+++ b/qbft/prepare.go
@@ -114,7 +114,7 @@ func validSignedPrepareForHeightRoundAndRootIgnoreSignature(
 		return errors.New("proposed data mismatch")
 	}
 
-	if len(signedPrepare.GetOperatorIDs()) != 1 {
+	if len(signedPrepare.OperatorIDs) != 1 {
 		return errors.New("msg allows 1 signer")
 	}
 

--- a/qbft/proposal.go
+++ b/qbft/proposal.go
@@ -68,7 +68,7 @@ func isValidProposal(
 	if msg.Height != state.Height {
 		return errors.New("wrong msg height")
 	}
-	if len(signedProposal.GetOperatorIDs()) != 1 {
+	if len(signedProposal.OperatorIDs) != 1 {
 		return errors.New("msg allows 1 signer")
 	}
 

--- a/qbft/round_change.go
+++ b/qbft/round_change.go
@@ -265,7 +265,7 @@ func validRoundChangeForDataIgnoreSignature(
 	if msg.Round != round {
 		return errors.New("wrong msg round")
 	}
-	if len(signedMsg.GetOperatorIDs()) != 1 {
+	if len(signedMsg.OperatorIDs) != 1 {
 		return errors.New("msg allows 1 signer")
 	}
 

--- a/qbft/spectest/tests/controller_spectest.go
+++ b/qbft/spectest/tests/controller_spectest.go
@@ -153,7 +153,7 @@ func (test *ControllerSpecTest) testBroadcastedDecided(
 			require.NoError(t, err)
 
 			if r1 == r2 &&
-				reflect.DeepEqual(runData.ExpectedDecidedState.BroadcastedDecided.GetOperatorIDs(), msg.GetOperatorIDs()) &&
+				reflect.DeepEqual(runData.ExpectedDecidedState.BroadcastedDecided.OperatorIDs, msg.OperatorIDs) &&
 				reflect.DeepEqual(runData.ExpectedDecidedState.BroadcastedDecided.Signatures, msg.Signatures) {
 				require.False(t, found)
 				found = true

--- a/qbft/state_test.go
+++ b/qbft/state_test.go
@@ -74,7 +74,7 @@ func TestState_Decoding(t *testing.T) {
 	}
 
 	require.EqualValues(t, [][]byte{{1, 2, 3, 4}}, decodedState.ProposalAcceptedForCurrentRound.Signatures)
-	require.EqualValues(t, []types.OperatorID{1}, decodedState.ProposalAcceptedForCurrentRound.GetOperatorIDs())
+	require.EqualValues(t, []types.OperatorID{1}, decodedState.ProposalAcceptedForCurrentRound.OperatorIDs)
 	require.EqualValues(t, qbft.CommitMsgType, decodedProposalMsg.MsgType)
 	require.EqualValues(t, 1, decodedProposalMsg.Height)
 	require.EqualValues(t, 2, decodedProposalMsg.Round)

--- a/ssv/aggregator.go
+++ b/ssv/aggregator.go
@@ -178,7 +178,8 @@ func (r *AggregatorRunner) ProcessPostConsensus(signedMsg *types.PartialSignatur
 		specSig := phase0.BLSSignature{}
 		copy(specSig[:], sig)
 
-		cd, err := types.CreateValidatorConsensusData(r.GetState().DecidedValue)
+		cd := &types.ValidatorConsensusData{}
+		err = cd.Decode(r.GetState().DecidedValue)
 		if err != nil {
 			return errors.Wrap(err, "could not create consensus data")
 		}
@@ -205,7 +206,8 @@ func (r *AggregatorRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot,
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
 func (r *AggregatorRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-	cd, err := types.CreateValidatorConsensusData(r.GetState().DecidedValue)
+	cd := &types.ValidatorConsensusData{}
+	err := cd.Decode(r.GetState().DecidedValue)
 	if err != nil {
 		return nil, types.DomainError, errors.Wrap(err, "could not create consensus data")
 	}

--- a/ssv/aggregator.go
+++ b/ssv/aggregator.go
@@ -144,9 +144,27 @@ func (r *AggregatorRunner) ProcessConsensus(signedMsg *types.SignedSSVMessage) e
 	}
 
 	msgID := types.NewMsgID(r.GetShare().DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
-	msgToBroadcast, err := types.PartialSignatureMessagesToSignedSSVMessage(postConsensusMsg, msgID, r.operatorSigner)
+
+	encodedMsg, err := postConsensusMsg.Encode()
 	if err != nil {
-		return errors.Wrap(err, "could not sign post-consensus partial signature message")
+		return err
+	}
+
+	ssvMsg := &types.SSVMessage{
+		MsgType: types.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
 	}
 
 	if err := r.GetNetwork().Broadcast(msgToBroadcast.SSVMessage.GetID(), msgToBroadcast); err != nil {
@@ -239,9 +257,27 @@ func (r *AggregatorRunner) executeDuty(duty types.Duty) error {
 	}
 
 	msgID := types.NewMsgID(r.GetShare().DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
-	msgToBroadcast, err := types.PartialSignatureMessagesToSignedSSVMessage(msgs, msgID, r.operatorSigner)
+
+	encodedMsg, err := msgs.Encode()
 	if err != nil {
-		return errors.Wrap(err, "could not sign pre-consensus partial signature message")
+		return err
+	}
+
+	ssvMsg := &types.SSVMessage{
+		MsgType: types.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
 	}
 
 	if err := r.GetNetwork().Broadcast(msgToBroadcast.SSVMessage.GetID(), msgToBroadcast); err != nil {

--- a/ssv/committee_runner.go
+++ b/ssv/committee_runner.go
@@ -154,8 +154,17 @@ func (cr CommitteeRunner) ProcessConsensus(msg *types.SignedSSVMessage) error {
 		return errors.Wrap(err, "failed to encode post consensus signature msg")
 	}
 
-	msgToBroadcast, err := types.SSVMessageToSignedSSVMessage(ssvMsg, cr.BaseRunner.QBFTController.CommitteeMember.OperatorID,
-		cr.operatorSigner.SignSSVMessage)
+	sig, err := cr.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{cr.BaseRunner.QBFTController.CommitteeMember.OperatorID},
+		SSVMessage:  ssvMsg,
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "could not create SignedSSVMessage from SSVMessage")
 	}

--- a/ssv/committee_runner.go
+++ b/ssv/committee_runner.go
@@ -403,8 +403,8 @@ func (cr *CommitteeRunner) expectedPostConsensusRootsAndBeaconObjects() (
 	beaconObjects = make(map[phase0.ValidatorIndex]map[[32]byte]ssz.HashRoot)
 	duty := cr.BaseRunner.State.StartingDuty.(*types.CommitteeDuty)
 	beaconVoteData := cr.BaseRunner.State.DecidedValue
-	beaconVote, err := types.NewBeaconVote(beaconVoteData)
-	if err != nil {
+	beaconVote := &types.BeaconVote{}
+	if err := beaconVote.Decode(beaconVoteData); err != nil {
 		return nil, nil, nil, errors.Wrap(err, "could not decode beacon vote")
 	}
 

--- a/ssv/proposer.go
+++ b/ssv/proposer.go
@@ -186,7 +186,8 @@ func (r *ProposerRunner) ProcessPostConsensus(signedMsg *types.PartialSignatureM
 		specSig := phase0.BLSSignature{}
 		copy(specSig[:], sig)
 
-		validatorConsensusData, err := types.CreateValidatorConsensusData(r.GetState().DecidedValue)
+		validatorConsensusData := &types.ValidatorConsensusData{}
+		err = validatorConsensusData.Decode(r.GetState().DecidedValue)
 		if err != nil {
 			return errors.Wrap(err, "could not create consensus data")
 		}
@@ -217,7 +218,8 @@ func (r *ProposerRunner) ProcessPostConsensus(signedMsg *types.PartialSignatureM
 // decidedBlindedBlock returns true if decided value has a blinded block, false if regular block
 // WARNING!! should be called after decided only
 func (r *ProposerRunner) decidedBlindedBlock() bool {
-	validatorConsensusData, err := types.CreateValidatorConsensusData(r.GetState().DecidedValue)
+	validatorConsensusData := &types.ValidatorConsensusData{}
+	err := validatorConsensusData.Decode(r.GetState().DecidedValue)
 	if err != nil {
 		return false
 	}
@@ -232,8 +234,8 @@ func (r *ProposerRunner) expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, p
 
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
 func (r *ProposerRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
-
-	validatorConsensusData, err := types.CreateValidatorConsensusData(r.GetState().DecidedValue)
+	validatorConsensusData := &types.ValidatorConsensusData{}
+	err := validatorConsensusData.Decode(r.GetState().DecidedValue)
 	if err != nil {
 		return nil, phase0.DomainType{}, errors.Wrap(err, "could not create consensus data")
 	}

--- a/ssv/proposer.go
+++ b/ssv/proposer.go
@@ -152,9 +152,27 @@ func (r *ProposerRunner) ProcessConsensus(signedMsg *types.SignedSSVMessage) err
 	}
 
 	msgID := types.NewMsgID(r.GetShare().DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
-	msgToBroadcast, err := types.PartialSignatureMessagesToSignedSSVMessage(postConsensusMsg, msgID, r.operatorSigner)
+
+	encodedMsg, err := postConsensusMsg.Encode()
 	if err != nil {
-		return errors.Wrap(err, "could not sign post-consensus partial signature message")
+		return err
+	}
+
+	ssvMsg := &types.SSVMessage{
+		MsgType: types.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
 	}
 
 	if err := r.GetNetwork().Broadcast(msgToBroadcast.SSVMessage.GetID(), msgToBroadcast); err != nil {
@@ -275,9 +293,27 @@ func (r *ProposerRunner) executeDuty(duty types.Duty) error {
 	}
 
 	msgID := types.NewMsgID(r.GetShare().DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
-	msgToBroadcast, err := types.PartialSignatureMessagesToSignedSSVMessage(msgs, msgID, r.operatorSigner)
+
+	encodedMsg, err := msgs.Encode()
 	if err != nil {
-		return errors.Wrap(err, "could not sign pre-consensus partial signature message")
+		return err
+	}
+
+	ssvMsg := &types.SSVMessage{
+		MsgType: types.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
 	}
 
 	if err := r.GetNetwork().Broadcast(msgToBroadcast.SSVMessage.GetID(), msgToBroadcast); err != nil {

--- a/ssv/sync_committee_aggregator.go
+++ b/ssv/sync_committee_aggregator.go
@@ -186,9 +186,27 @@ func (r *SyncCommitteeAggregatorRunner) ProcessConsensus(signedMsg *types.Signed
 	}
 
 	msgID := types.NewMsgID(r.GetShare().DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
-	msgToBroadcast, err := types.PartialSignatureMessagesToSignedSSVMessage(postConsensusMsg, msgID, r.operatorSigner)
+
+	encodedMsg, err := postConsensusMsg.Encode()
 	if err != nil {
-		return errors.Wrap(err, "could not sign post-consensus partial signature message")
+		return err
+	}
+
+	ssvMsg := &types.SSVMessage{
+		MsgType: types.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
 	}
 
 	if err := r.GetNetwork().Broadcast(msgToBroadcast.SSVMessage.GetID(), msgToBroadcast); err != nil {
@@ -352,9 +370,27 @@ func (r *SyncCommitteeAggregatorRunner) executeDuty(duty types.Duty) error {
 	}
 
 	msgID := types.NewMsgID(r.GetShare().DomainType, r.GetShare().ValidatorPubKey[:], r.BaseRunner.RunnerRoleType)
-	msgToBroadcast, err := types.PartialSignatureMessagesToSignedSSVMessage(msgs, msgID, r.operatorSigner)
+
+	encodedMsg, err := msgs.Encode()
 	if err != nil {
-		return errors.Wrap(err, "could not sign pre-consensus partial signature message")
+		return err
+	}
+
+	ssvMsg := &types.SSVMessage{
+		MsgType: types.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
 	}
 
 	if err := r.GetNetwork().Broadcast(msgToBroadcast.SSVMessage.GetID(), msgToBroadcast); err != nil {

--- a/ssv/sync_committee_aggregator.go
+++ b/ssv/sync_committee_aggregator.go
@@ -208,7 +208,8 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(signedMsg *types.Pa
 	}
 
 	// get contributions
-	validatorConsensusData, err := types.CreateValidatorConsensusData(r.GetState().DecidedValue)
+	validatorConsensusData := &types.ValidatorConsensusData{}
+	err = validatorConsensusData.Decode(r.GetState().DecidedValue)
 	if err != nil {
 		return errors.Wrap(err, "could not create consensus data")
 	}
@@ -299,7 +300,8 @@ func (r *SyncCommitteeAggregatorRunner) expectedPreConsensusRootsAndDomain() ([]
 // expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
 func (r *SyncCommitteeAggregatorRunner) expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error) {
 	// get contributions
-	validatorConsensusData, err := types.CreateValidatorConsensusData(r.GetState().DecidedValue)
+	validatorConsensusData := &types.ValidatorConsensusData{}
+	err := validatorConsensusData.Decode(r.GetState().DecidedValue)
 	if err != nil {
 		return nil, types.DomainError, errors.Wrap(err, "could not create consensus data")
 	}

--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -140,9 +140,27 @@ func (r *ValidatorRegistrationRunner) executeDuty(duty types.Duty) error {
 	}
 
 	msgID := types.NewMsgID(r.GetShare().DomainType, r.GetShare().ValidatorPubKey[:], types.RunnerRole(r.BaseRunner.RunnerRoleType))
-	msgToBroadcast, err := types.PartialSignatureMessagesToSignedSSVMessage(msgs, msgID, r.operatorSigner)
+
+	encodedMsg, err := msgs.Encode()
 	if err != nil {
-		return errors.Wrap(err, "could not sign pre-consensus partial signature message")
+		return err
+	}
+
+	ssvMsg := &types.SSVMessage{
+		MsgType: types.SSVPartialSignatureMsgType,
+		MsgID:   msgID,
+		Data:    encodedMsg,
+	}
+
+	sig, err := r.operatorSigner.SignSSVMessage(ssvMsg)
+	if err != nil {
+		return errors.Wrap(err, "could not sign SSVMessage")
+	}
+
+	msgToBroadcast := &types.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []types.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
 	}
 
 	if err := r.GetNetwork().Broadcast(msgToBroadcast.SSVMessage.GetID(), msgToBroadcast); err != nil {

--- a/types/consensus_data.go
+++ b/types/consensus_data.go
@@ -108,15 +108,6 @@ type BeaconVote struct {
 	Target    *phase0.Checkpoint
 }
 
-// NewBeaconVote creates a new BeaconVote object
-func NewBeaconVote(rawSSZ []byte) (*BeaconVote, error) {
-	vote := &BeaconVote{}
-	if err := vote.Decode(rawSSZ); err != nil {
-		return nil, err
-	}
-	return vote, nil
-}
-
 // Encode the BeaconVote object
 func (b *BeaconVote) Encode() ([]byte, error) {
 	return b.MarshalSSZ()

--- a/types/consensus_data.go
+++ b/types/consensus_data.go
@@ -169,12 +169,6 @@ type ValidatorConsensusData struct {
 	DataSSZ []byte `ssz-max:"4194304"` // 2^22
 }
 
-func CreateValidatorConsensusData(rawSSZ []byte) (*ValidatorConsensusData, error) {
-	cd := &ValidatorConsensusData{}
-	err := cd.Decode(rawSSZ)
-	return cd, err
-}
-
 func (cid *ValidatorConsensusData) Validate() error {
 	switch cid.Duty.Type {
 	case BNRoleAggregator:

--- a/types/messages.go
+++ b/types/messages.go
@@ -191,19 +191,6 @@ func (msg *SignedSSVMessage) Validate() error {
 	return nil
 }
 
-func SSVMessageToSignedSSVMessage(msg *SSVMessage, operatorID OperatorID, signSSVMessageF SignSSVMessageF) (*SignedSSVMessage, error) {
-	sig, err := signSSVMessageF(msg)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not sign SSVMessage")
-	}
-
-	return &SignedSSVMessage{
-		Signatures:  [][]byte{sig},
-		OperatorIDs: []OperatorID{operatorID},
-		SSVMessage:  msg,
-	}, nil
-}
-
 // DeepCopy returns a new instance of SignedMessage, deep copied
 func (signedMsg *SignedSSVMessage) DeepCopy() *SignedSSVMessage {
 	ret := &SignedSSVMessage{

--- a/types/messages.go
+++ b/types/messages.go
@@ -132,11 +132,6 @@ type SignedSSVMessage struct {
 	FullData []byte `ssz-max:"4219184"`
 }
 
-// GetOperatorIDs returns the dutyExecutor operator ID
-func (msg *SignedSSVMessage) GetOperatorIDs() []OperatorID {
-	return msg.OperatorIDs
-}
-
 // Encode returns a msg encoded bytes or error
 func (msg *SignedSSVMessage) Encode() ([]byte, error) {
 	return msg.MarshalSSZ()
@@ -212,10 +207,10 @@ func SSVMessageToSignedSSVMessage(msg *SSVMessage, operatorID OperatorID, signSS
 // DeepCopy returns a new instance of SignedMessage, deep copied
 func (signedMsg *SignedSSVMessage) DeepCopy() *SignedSSVMessage {
 	ret := &SignedSSVMessage{
-		OperatorIDs: make([]OperatorID, len(signedMsg.GetOperatorIDs())),
+		OperatorIDs: make([]OperatorID, len(signedMsg.OperatorIDs)),
 		Signatures:  make([][]byte, len(signedMsg.Signatures)),
 	}
-	copy(ret.OperatorIDs, signedMsg.GetOperatorIDs())
+	copy(ret.OperatorIDs, signedMsg.OperatorIDs)
 	copy(ret.Signatures, signedMsg.Signatures)
 
 	retSSV := &SSVMessage{
@@ -238,11 +233,11 @@ func (signedMsg *SignedSSVMessage) DeepCopy() *SignedSSVMessage {
 
 // MatchedSigners returns true if the provided signer ids are equal to GetOperatorIDs() without order significance
 func (msg *SignedSSVMessage) MatchedSigners(ids []OperatorID) bool {
-	if len(msg.GetOperatorIDs()) != len(ids) {
+	if len(msg.OperatorIDs) != len(ids) {
 		return false
 	}
 
-	for _, id := range msg.GetOperatorIDs() {
+	for _, id := range msg.OperatorIDs {
 		found := false
 		for _, id2 := range ids {
 			if id == id2 {
@@ -259,7 +254,7 @@ func (msg *SignedSSVMessage) MatchedSigners(ids []OperatorID) bool {
 
 // CommonSigners returns true if there is at least 1 common signer
 func (msg *SignedSSVMessage) CommonSigners(ids []OperatorID) bool {
-	for _, id := range msg.GetOperatorIDs() {
+	for _, id := range msg.OperatorIDs {
 		for _, id2 := range ids {
 			if id == id2 {
 				return true
@@ -271,7 +266,7 @@ func (msg *SignedSSVMessage) CommonSigners(ids []OperatorID) bool {
 
 // Aggregate will aggregate the signed message if possible (unique signers, same digest, valid)
 func (msg *SignedSSVMessage) Aggregate(msgToAggregate *SignedSSVMessage) error {
-	if msg.CommonSigners(msgToAggregate.GetOperatorIDs()) {
+	if msg.CommonSigners(msgToAggregate.OperatorIDs) {
 		return errors.New("duplicate signers")
 	}
 
@@ -288,7 +283,7 @@ func (msg *SignedSSVMessage) Aggregate(msgToAggregate *SignedSSVMessage) error {
 	}
 
 	msg.Signatures = append(msg.Signatures, msgToAggregate.Signatures...)
-	msg.OperatorIDs = append(msg.OperatorIDs, msgToAggregate.GetOperatorIDs()...)
+	msg.OperatorIDs = append(msg.OperatorIDs, msgToAggregate.OperatorIDs...)
 
 	return nil
 }
@@ -302,7 +297,7 @@ func (msg *SignedSSVMessage) CheckSignersInCommittee(operators []*Operator) bool
 	}
 
 	// Check that all message signers belong to the map
-	for _, signer := range msg.GetOperatorIDs() {
+	for _, signer := range msg.OperatorIDs {
 		if _, ok := committeeMap[signer]; !ok {
 			return false
 		}

--- a/types/partial_sig_message.go
+++ b/types/partial_sig_message.go
@@ -71,30 +71,6 @@ func (msgs PartialSignatureMessages) ValidateForSigner(signer OperatorID) error 
 	return nil
 }
 
-func PartialSignatureMessagesToSignedSSVMessage(psigMsgs *PartialSignatureMessages, msgID MessageID, operatorSigner OperatorSigner) (*SignedSSVMessage, error) {
-	encodedMsg, err := psigMsgs.Encode()
-	if err != nil {
-		return nil, err
-	}
-
-	ssvMsg := &SSVMessage{
-		MsgType: SSVPartialSignatureMsgType,
-		MsgID:   msgID,
-		Data:    encodedMsg,
-	}
-
-	sig, err := operatorSigner.SignSSVMessage(ssvMsg)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not sign SSVMessage")
-	}
-
-	return &SignedSSVMessage{
-		Signatures:  [][]byte{sig},
-		OperatorIDs: []OperatorID{operatorSigner.GetOperatorID()},
-		SSVMessage:  ssvMsg,
-	}, nil
-}
-
 // PartialSignatureMessage is a msg for partial Beacon chain related signatures (like partial attestation, block, randao sigs)
 type PartialSignatureMessage struct {
 	PartialSignature Signature `ssz-size:"96"` // The Beacon chain partial Signature for a duty

--- a/types/spectest/tests/committeemember/test.go
+++ b/types/spectest/tests/committeemember/test.go
@@ -27,7 +27,7 @@ func (test *CommitteeMemberTest) TestName() string {
 func (test *CommitteeMemberTest) GetUniqueMessageSignersCount() int {
 	uniqueSigners := make(map[uint64]bool)
 
-	for _, element := range test.Message.GetOperatorIDs() {
+	for _, element := range test.Message.OperatorIDs {
 		uniqueSigners[element] = true
 	}
 

--- a/types/spectest/tests/share/test.go
+++ b/types/spectest/tests/share/test.go
@@ -27,7 +27,7 @@ func (test *ShareTest) TestName() string {
 func (test *ShareTest) GetUniqueMessageSignersCount() int {
 	uniqueSigners := make(map[uint64]bool)
 
-	for _, element := range test.Message.GetOperatorIDs() {
+	for _, element := range test.Message.OperatorIDs {
 		uniqueSigners[element] = true
 	}
 


### PR DESCRIPTION
## Overview

This PR removes the following convenience functions:
- `CreateValidatorConsensusData`
- `SSVMessageToSignedSSVMessage`
- `PartialSignatureMessagesToSignedSSVMessage`
- `NewBeaconVote`

and the redundant `SignedSSVMessage.GetOperatorID` function.