### PR TITLE
Use GetShare to avoid duplicated code

### DIFF
--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -168,13 +168,9 @@ func (r *ValidatorRegistrationRunner) executeDuty(duty types.Duty) error {
 
 func (r *ValidatorRegistrationRunner) calculateValidatorRegistration(duty types.Duty) (*v1.ValidatorRegistration, error) {
 
-	if len(r.BaseRunner.Share) == 0 {
+	share := r.GetShare()
+	if share == nil {
 		return nil, errors.New("no share to get validator public key")
-	}
-	var share *types.Share
-	for _, shareInstance := range r.BaseRunner.Share {
-		share = shareInstance
-		break
 	}
 
 	pk := phase0.BLSPubKey{}

--- a/ssv/validator_registration.go
+++ b/ssv/validator_registration.go
@@ -76,13 +76,9 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(signedMsg *types.Parti
 	copy(specSig[:], fullSig)
 
 	// Get share
-	if len(r.BaseRunner.Share) == 0 {
+	share := r.GetShare()
+	if share == nil {
 		return errors.New("no share to get validator public key")
-	}
-	var share *types.Share
-	for _, shareInstance := range r.BaseRunner.Share {
-		share = shareInstance
-		break
 	}
 
 	if err := r.beacon.SubmitValidatorRegistration(share.ValidatorPubKey[:],


### PR DESCRIPTION
## Overview

This PR calls `GetShare` whenever there's a duplicated code that gets a sample `Share` from the runner's `ShareMap` using the for loop behaviour.