### PR TITLE
Refactor PartialSigContainer.HasSigner: avoid duplication code and rename

### DIFF
--- a/ssv/partial_sig_container.go
+++ b/ssv/partial_sig_container.go
@@ -38,7 +38,7 @@ func (ps *PartialSigContainer) AddSignature(sigMsg *types.PartialSignatureMessag
 }
 
 // HasSigner returns true if container has signature for signer and signing root, else it returns false
-func (ps *PartialSigContainer) HasSigner(validatorIndex phase0.ValidatorIndex, signer types.OperatorID, signingRoot [32]byte) bool {
+func (ps *PartialSigContainer) HasSignature(validatorIndex phase0.ValidatorIndex, signer types.OperatorID, signingRoot [32]byte) bool {
 	_, err := ps.GetSignature(validatorIndex, signer, signingRoot)
 	return err == nil
 }

--- a/ssv/partial_sig_container.go
+++ b/ssv/partial_sig_container.go
@@ -37,18 +37,13 @@ func (ps *PartialSigContainer) AddSignature(sigMsg *types.PartialSignatureMessag
 	}
 }
 
-// Returns if container has signature for signer and signing root
+// HasSigner returns true if container has signature for signer and signing root, else it returns false
 func (ps *PartialSigContainer) HasSigner(validatorIndex phase0.ValidatorIndex, signer types.OperatorID, signingRoot [32]byte) bool {
-	if ps.Signatures[validatorIndex] == nil {
-		return false
-	}
-	if ps.Signatures[validatorIndex][rootHex(signingRoot)] == nil {
-		return false
-	}
-	return ps.Signatures[validatorIndex][rootHex(signingRoot)][signer] != nil
+	_, err := ps.GetSignature(validatorIndex, signer, signingRoot)
+	return err == nil
 }
 
-// Return signature for given root and signer
+// GetSignature returns the signature for a given root and signer
 func (ps *PartialSigContainer) GetSignature(validatorIndex phase0.ValidatorIndex, signer types.OperatorID, signingRoot [32]byte) (types.Signature, error) {
 	if ps.Signatures[validatorIndex] == nil {
 		return nil, errors.New("Dont have signature for the given validator index")

--- a/ssv/runner.go
+++ b/ssv/runner.go
@@ -184,7 +184,7 @@ func (b *BaseRunner) basePartialSigMsgProcessing(
 		prevQuorum := container.HasQuorum(msg.ValidatorIndex, msg.SigningRoot)
 
 		// Check if it has two signatures for the same signer
-		if container.HasSigner(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
+		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
 			b.resolveDuplicateSignature(container, msg)
 		} else {
 			container.AddSignature(msg)


### PR DESCRIPTION
## Overview

This PR performs two changes:
1. Uses `PartialSigContainer.GetSignature` in `PartialSigContainer.HasSigner` to avoid duplication code.
2. Renames `PartialSigContainer.HasSigner` to `PartialSigContainer.HasSignature`, since we're actually looking for the existence (or not) of a signature.