### PR TITLE
Fix RunnerRoleType argument name in NewBaseRunner

### DIFF
--- a/ssv/runner.go
+++ b/ssv/runner.go
@@ -59,7 +59,7 @@ func NewBaseRunner(
 	share map[spec.ValidatorIndex]*types.Share,
 	controller *qbft.Controller,
 	beaconNetwork types.BeaconNetwork,
-	beaconRoleType types.RunnerRole,
+	runnerRoleType types.RunnerRole,
 	operatorSigner types.OperatorSigner,
 	highestDecidedSlot spec.Slot,
 ) *BaseRunner {
@@ -68,7 +68,7 @@ func NewBaseRunner(
 		Share:              share,
 		QBFTController:     controller,
 		BeaconNetwork:      beaconNetwork,
-		RunnerRoleType:     beaconRoleType,
+		RunnerRoleType:     runnerRoleType,
 		highestDecidedSlot: highestDecidedSlot,
 	}
 }


### PR DESCRIPTION
## Overview

This PR simply fixes the name of the `RunnerRoleType` argument in `NewBaseRunner`, since it used the deprecated field name (`beaconRoleType`).