### PR TITLE
TestingKeyManager: Slashing by Slot

### DIFF
--- a/ssv/spectest/all_tests.go
+++ b/ssv/spectest/all_tests.go
@@ -171,6 +171,7 @@ var AllTests = []tests.TestF{
 	valcheckattestations.Valid,
 	valcheckattestations.MinoritySlashable,
 	valcheckattestations.MajoritySlashable,
+	valcheckattestations.ValidNonSlashableSlot,
 
 	valcheckproposer.BlindedBlock,
 

--- a/ssv/spectest/tests/msg_processing_spectest.go
+++ b/ssv/spectest/tests/msg_processing_spectest.go
@@ -125,8 +125,8 @@ func (test *MsgProcessingSpecTest) runPreTesting() (*ssv.Validator, *ssv.Committ
 			}
 			if test.DecidedSlashable && IsQBFTProposalMessage(msg) {
 				for _, validatorShare := range test.Runner.GetBaseRunner().Share {
-					test.Runner.GetSigner().(*testingutils.TestingKeyManager).AddSlashableDataRoot(validatorShare.
-						SharePubKey, testingutils.TestingAttestationDataRoot[:])
+					test.Runner.GetSigner().(*testingutils.TestingKeyManager).AddSlashableSlot(validatorShare.
+						SharePubKey, testingutils.TestingAttestationData.Slot)
 				}
 			}
 		}

--- a/ssv/spectest/tests/valcheck/valcheckattestations/attestation_data_nil.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/attestation_data_nil.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
 	"github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv-spec/types/testingutils"
 )
 
 // BeaconVoteDataNil tests consensus data != nil
@@ -18,6 +19,7 @@ func BeaconVoteDataNil() tests.SpecTest {
 		Name:          "consensus data value check nil",
 		Network:       types.PraterNetwork,
 		RunnerRole:    types.RoleCommittee,
+		DutySlot:      testingutils.TestingDutySlot,
 		Input:         input,
 		ExpectedError: "attestation data source >= target",
 	}

--- a/ssv/spectest/tests/valcheck/valcheckattestations/far_future_target.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/far_future_target.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
 	"github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv-spec/types/testingutils"
 )
 
 // FarFutureTarget tests AttestationData.Target.Epoch higher than expected
@@ -27,6 +28,7 @@ func FarFutureTarget() tests.SpecTest {
 		Name:          "attestation value check far future target",
 		Network:       types.BeaconTestNetwork,
 		RunnerRole:    types.RoleCommittee,
+		DutySlot:      testingutils.TestingDutySlot,
 		Input:         input,
 		ExpectedError: "attestation data target epoch is into far future",
 	}

--- a/ssv/spectest/tests/valcheck/valcheckattestations/majority_slashable.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/majority_slashable.go
@@ -2,8 +2,8 @@ package valcheckattestations
 
 import (
 	"encoding/hex"
-	"math"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
@@ -25,16 +25,6 @@ func MajoritySlashable() tests.SpecTest {
 		},
 	}
 
-	attestationData := &spec.AttestationData{
-		Slot:            testingutils.TestingDutySlot,
-		Index:           math.MaxUint64,
-		BeaconBlockRoot: data.BlockRoot,
-		Source:          data.Source,
-		Target:          data.Target,
-	}
-
-	r, _ := attestationData.HashTreeRoot()
-
 	input, _ := data.Encode()
 
 	// Get shares
@@ -48,18 +38,19 @@ func MajoritySlashable() tests.SpecTest {
 	}
 
 	// Make slashable map with majority
-	slashableMap := make(map[string][][]byte)
+	slashableMap := make(map[string][]phase0.Slot)
 	for i := 0; i < int(keySet.Threshold); i++ {
-		slashableMap[sharesPKString[i]] = [][]byte{r[:]}
+		slashableMap[sharesPKString[i]] = []phase0.Slot{testingutils.TestingDutySlot}
 	}
 
 	return &valcheck.SpecTest{
-		Name:               "attestation value check with slashable majority",
-		Network:            types.BeaconTestNetwork,
-		RunnerRole:         types.RoleCommittee,
-		Input:              input,
-		ExpectedError:      "slashable attestation",
-		SlashableDataRoots: slashableMap,
-		ShareValidatorsPK:  sharesPKBytes,
+		Name:              "attestation value check with slashable majority",
+		Network:           types.BeaconTestNetwork,
+		RunnerRole:        types.RoleCommittee,
+		DutySlot:          testingutils.TestingDutySlot,
+		Input:             input,
+		ExpectedError:     "slashable attestation",
+		SlashableSlots:    slashableMap,
+		ShareValidatorsPK: sharesPKBytes,
 	}
 }

--- a/ssv/spectest/tests/valcheck/valcheckattestations/minority_slashable.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/minority_slashable.go
@@ -2,8 +2,8 @@ package valcheckattestations
 
 import (
 	"encoding/hex"
-	"math"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
@@ -25,16 +25,6 @@ func MinoritySlashable() tests.SpecTest {
 		},
 	}
 
-	attestationData := &spec.AttestationData{
-		Slot:            testingutils.TestingDutySlot,
-		Index:           math.MaxUint64,
-		BeaconBlockRoot: data.BlockRoot,
-		Source:          data.Source,
-		Target:          data.Target,
-	}
-
-	r, _ := attestationData.HashTreeRoot()
-
 	input, _ := data.Encode()
 
 	// Get shares
@@ -48,19 +38,20 @@ func MinoritySlashable() tests.SpecTest {
 	}
 
 	// Make slashable map with minority
-	slashableMap := map[string][][]byte{
+	slashableMap := map[string][]phase0.Slot{
 		sharesPKString[0]: {
-			r[:],
+			testingutils.TestingDutySlot,
 		},
 	}
 
 	return &valcheck.SpecTest{
-		Name:               "attestation value check with slashable minority",
-		Network:            types.BeaconTestNetwork,
-		RunnerRole:         types.RoleCommittee,
-		Input:              input,
-		ExpectedError:      "slashable attestation",
-		SlashableDataRoots: slashableMap,
-		ShareValidatorsPK:  sharesPKBytes,
+		Name:              "attestation value check with slashable minority",
+		Network:           types.BeaconTestNetwork,
+		RunnerRole:        types.RoleCommittee,
+		DutySlot:          testingutils.TestingDutySlot,
+		Input:             input,
+		ExpectedError:     "slashable attestation",
+		SlashableSlots:    slashableMap,
+		ShareValidatorsPK: sharesPKBytes,
 	}
 }

--- a/ssv/spectest/tests/valcheck/valcheckattestations/slashable.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/slashable.go
@@ -2,8 +2,8 @@ package valcheckattestations
 
 import (
 	"encoding/hex"
-	"math"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
@@ -25,16 +25,6 @@ func Slashable() tests.SpecTest {
 		},
 	}
 
-	attestationData := &spec.AttestationData{
-		Slot:            testingutils.TestingDutySlot,
-		Index:           math.MaxUint64,
-		BeaconBlockRoot: data.BlockRoot,
-		Source:          data.Source,
-		Target:          data.Target,
-	}
-
-	r, _ := attestationData.HashTreeRoot()
-
 	input, _ := data.Encode()
 
 	keySet := testingutils.Testing4SharesSet()
@@ -45,11 +35,12 @@ func Slashable() tests.SpecTest {
 		Name:          "attestation value check slashable",
 		Network:       types.BeaconTestNetwork,
 		RunnerRole:    types.RoleCommittee,
+		DutySlot:      testingutils.TestingDutySlot,
 		Input:         input,
 		ExpectedError: "slashable attestation",
-		SlashableDataRoots: map[string][][]byte{
+		SlashableSlots: map[string][]phase0.Slot{
 			shareString: {
-				r[:],
+				testingutils.TestingDutySlot,
 			},
 		},
 		ShareValidatorsPK: []types.ShareValidatorPK{sharePKBytes},

--- a/ssv/spectest/tests/valcheck/valcheckattestations/source_higher_than_target.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/source_higher_than_target.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
 	"github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv-spec/types/testingutils"
 )
 
 // SourceHigherThanTarget tests AttestationData.Source.Epoch higher than target
@@ -27,6 +28,7 @@ func SourceHigherThanTarget() tests.SpecTest {
 		Name:          "attestation value check source higher than target",
 		Network:       types.BeaconTestNetwork,
 		RunnerRole:    types.RoleCommittee,
+		DutySlot:      testingutils.TestingDutySlot,
 		Input:         input,
 		ExpectedError: "attestation data source >= target",
 	}

--- a/ssv/spectest/tests/valcheck/valcheckattestations/valid.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/valid.go
@@ -13,6 +13,7 @@ func Valid() tests.SpecTest {
 		Name:       "attestation value check valid",
 		Network:    types.PraterNetwork,
 		RunnerRole: types.RoleCommittee,
+		DutySlot:   testingutils.TestingDutySlot,
 		Input:      testingutils.TestBeaconVoteByts,
 	}
 }

--- a/ssv/spectest/tests/valcheck/valcheckattestations/valid_non_slashable_slot.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/valid_non_slashable_slot.go
@@ -1,0 +1,47 @@
+package valcheckattestations
+
+import (
+	"encoding/hex"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
+	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
+	"github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv-spec/types/testingutils"
+)
+
+// ValidNonSlashableSlot tests a valid AttestationData with a slot that is not slashable
+func ValidNonSlashableSlot() tests.SpecTest {
+	data := &types.BeaconVote{
+		BlockRoot: spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+		Source: &spec.Checkpoint{
+			Epoch: 0,
+			Root:  spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+		},
+		Target: &spec.Checkpoint{
+			Epoch: 1,
+			Root:  spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+		},
+	}
+
+	input, _ := data.Encode()
+
+	keySet := testingutils.Testing4SharesSet()
+	sharePKBytes := keySet.Shares[1].Serialize()
+	shareString := hex.EncodeToString(sharePKBytes)
+
+	return &valcheck.SpecTest{
+		Name:       "attestation valid with non slashable slot",
+		Network:    types.BeaconTestNetwork,
+		RunnerRole: types.RoleCommittee,
+		DutySlot:   testingutils.TestingDutySlot + 1,
+		Input:      input,
+		SlashableSlots: map[string][]phase0.Slot{
+			shareString: {
+				testingutils.TestingDutySlot,
+			},
+		},
+		ShareValidatorsPK: []types.ShareValidatorPK{sharePKBytes},
+	}
+}


### PR DESCRIPTION
## Overview

This PR modifies the `TestingKeyManager` to do the slashing check based on the slot, instead of the data root.

### Adjusted tests:
- [x] ValCheck/Attestations: Majority slashable
- [x] ValCheck/Attestations: Minority slash able
- [x] ValCheck/Attestations: Slashable

### New test:
- [x] ValCheck/Attestations: Valid BeaconVote with a slot that is different from the slashing slot.