### PR TITLE
Remove leftover: HighestDutySlotMap in CommitteeAlias

### DIFF
--- a/ssv/json_testutils.go
+++ b/ssv/json_testutils.go
@@ -123,10 +123,9 @@ func (c *Committee) GetRoot() ([32]byte, error) {
 func (c *Committee) MarshalJSON() ([]byte, error) {
 
 	type CommitteeAlias struct {
-		Runners            map[spec.Slot]*CommitteeRunner
-		CommitteeMember    types.CommitteeMember
-		Share              map[spec.ValidatorIndex]*types.Share
-		HighestDutySlotMap map[types.BeaconRole]map[spec.ValidatorIndex]spec.Slot
+		Runners         map[spec.Slot]*CommitteeRunner
+		CommitteeMember types.CommitteeMember
+		Share           map[spec.ValidatorIndex]*types.Share
 	}
 
 	// Create object and marshal
@@ -144,10 +143,9 @@ func (c *Committee) MarshalJSON() ([]byte, error) {
 func (c *Committee) UnmarshalJSON(data []byte) error {
 
 	type CommitteeAlias struct {
-		Runners            map[spec.Slot]*CommitteeRunner
-		CommitteeMember    types.CommitteeMember
-		Share              map[spec.ValidatorIndex]*types.Share
-		HighestDutySlotMap map[types.BeaconRole]map[spec.ValidatorIndex]spec.Slot
+		Runners         map[spec.Slot]*CommitteeRunner
+		CommitteeMember types.CommitteeMember
+		Share           map[spec.ValidatorIndex]*types.Share
 	}
 
 	// Unmarshal the JSON data into the auxiliary struct

--- a/ssv/spectest/generate/state_comparison/committee_CommitteeSpecTest/empty committee duty.json
+++ b/ssv/spectest/generate/state_comparison/committee_CommitteeSpecTest/empty committee duty.json
@@ -165,6 +165,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/1 attestation.json
@@ -2420,6 +2420,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/1 attestations 1 sync committees.json
@@ -2435,6 +2435,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/1 sync committee.json
@@ -2424,6 +2424,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/30 attestation.json
@@ -8597,6 +8597,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/30 attestations 30 sync committees.json
@@ -9047,6 +9047,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/decided/30 sync committee.json
@@ -8717,6 +8717,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 1 attestations 1 sync committees.json
@@ -4717,6 +4717,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 1 sync committee.json
@@ -4690,6 +4690,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 30 attestations 30 sync committees.json
@@ -15360,6 +15360,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for 30 sync committee.json
@@ -14550,6 +14550,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for1 attestation.json
@@ -4682,6 +4682,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 1 sucessful for30 attestation.json
@@ -14310,6 +14310,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 1 attestations 1 sync committees.json
@@ -6999,6 +6999,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 1 sync committee.json
@@ -6956,6 +6956,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 30 attestations 30 sync committees.json
@@ -21673,6 +21673,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for 30 sync committee.json
@@ -20383,6 +20383,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for1 attestation.json
@@ -6944,6 +6944,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/1 fails 2 sucessful for30 attestation.json
@@ -20023,6 +20023,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 1 attestations 1 sync committees.json
@@ -6986,6 +6986,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 1 sync committee.json
@@ -6948,6 +6948,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 30 attestations 30 sync committees.json
@@ -21312,6 +21312,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for 30 sync committee.json
@@ -20172,6 +20172,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for1 attestation.json
@@ -6936,6 +6936,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 1 sucessful for30 attestation.json
@@ -19812,6 +19812,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 1 attestations 1 sync committees.json
@@ -9268,6 +9268,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 1 sync committee.json
@@ -9214,6 +9214,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 30 attestations 30 sync committees.json
@@ -27625,6 +27625,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for 30 sync committee.json
@@ -26005,6 +26005,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for1 attestation.json
@@ -9198,6 +9198,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/failed_than_successful_duties/2 fails 2 sucessful for30 attestation.json
@@ -25525,6 +25525,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/1 attestation.json
@@ -2428,6 +2428,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/1 attestations 1 sync committees.json
@@ -2448,6 +2448,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/1 sync committee.json
@@ -2432,6 +2432,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/30 attestation.json
@@ -8808,6 +8808,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/30 attestations 30 sync committees.json
@@ -9408,6 +9408,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/happy_flow/30 sync committee.json
@@ -8928,6 +8928,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_does_not_exist/30 attestation 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_does_not_exist/30 attestation 30 sync committee.json
@@ -7175,6 +7175,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_does_not_exist/30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_does_not_exist/30 attestation.json
@@ -6725,6 +6725,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_does_not_exist/30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_does_not_exist/30 sync committee.json
@@ -6845,6 +6845,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_finished/30 attestation 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_finished/30 attestation 30 sync committee.json
@@ -13488,6 +13488,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_finished/30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_finished/30 attestation.json
@@ -12438,6 +12438,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_finished/30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_finished/30 sync committee.json
@@ -12678,6 +12678,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_not_finished/30 attestation 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_not_finished/30 attestation 30 sync committee.json
@@ -13127,6 +13127,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_not_finished/30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_not_finished/30 attestation.json
@@ -12227,6 +12227,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_not_finished/30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/past_msg_duty_not_finished/30 sync committee.json
@@ -12467,6 +12467,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/proposal_with_consensus_data/30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/proposal_with_consensus_data/30 attestation.json
@@ -6725,6 +6725,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/proposal_with_consensus_data/30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/proposal_with_consensus_data/30 attestations 30 sync committees.json
@@ -7175,6 +7175,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/proposal_with_consensus_data/30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/proposal_with_consensus_data/30 sync committee.json
@@ -6845,6 +6845,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 1 attestation.json
@@ -2420,6 +2420,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 1 attestations 1 sync committees.json
@@ -2435,6 +2435,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 1 sync committee.json
@@ -2424,6 +2424,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 30 attestation.json
@@ -8597,6 +8597,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 30 attestations 30 sync committees.json
@@ -9047,6 +9047,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/1 duties 30 sync committee.json
@@ -8717,6 +8717,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 1 attestation.json
@@ -4674,6 +4674,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 1 attestations 1 sync committees.json
@@ -4704,6 +4704,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 1 sync committee.json
@@ -4682,6 +4682,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 30 attestation.json
@@ -14099,6 +14099,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 30 attestations 30 sync committees.json
@@ -14999,6 +14999,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/2 duties 30 sync committee.json
@@ -14339,6 +14339,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 1 attestation.json
@@ -9182,6 +9182,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 1 attestations 1 sync committees.json
@@ -9242,6 +9242,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 1 sync committee.json
@@ -9198,6 +9198,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 30 attestation.json
@@ -25103,6 +25103,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 30 attestations 30 sync committees.json
@@ -26903,6 +26903,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_decided_duties/4 duties 30 sync committee.json
@@ -25583,6 +25583,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 1 attestation.json
@@ -2428,6 +2428,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 1 attestations 1 sync committees.json
@@ -2448,6 +2448,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 1 sync committee.json
@@ -2432,6 +2432,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 30 attestation.json
@@ -8808,6 +8808,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 30 attestations 30 sync committees.json
@@ -9408,6 +9408,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/1 duties 30 sync committee.json
@@ -8928,6 +8928,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 1 attestation.json
@@ -4690,6 +4690,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 1 attestations 1 sync committees.json
@@ -4730,6 +4730,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 1 sync committee.json
@@ -4698,6 +4698,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 30 attestation.json
@@ -14521,6 +14521,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 30 attestations 30 sync committees.json
@@ -15721,6 +15721,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/2 duties 30 sync committee.json
@@ -14761,6 +14761,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 1 attestation.json
@@ -9214,6 +9214,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 1 attestations 1 sync committees.json
@@ -9294,6 +9294,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 1 sync committee.json
@@ -9230,6 +9230,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 30 attestation.json
@@ -25947,6 +25947,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 30 attestations 30 sync committees.json
@@ -28347,6 +28347,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/sequenced_happy_flow_duties/4 duties 30 sync committee.json
@@ -26427,6 +26427,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 1 attestation.json
@@ -4674,6 +4674,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 1 attestations 1 sync committees.json
@@ -4704,6 +4704,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 1 sync committee.json
@@ -4682,6 +4682,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 30 attestation.json
@@ -14099,6 +14099,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 30 attestations 30 sync committees.json
@@ -14999,6 +14999,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/2 duties 30 sync committee.json
@@ -14339,6 +14339,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 1 attestation.json
@@ -9182,6 +9182,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 1 attestations 1 sync committees.json
@@ -9242,6 +9242,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 1 sync committee.json
@@ -9198,6 +9198,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 30 attestation.json
@@ -25103,6 +25103,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 30 attestations 30 sync committees.json
@@ -26903,6 +26903,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_decided_duties/4 duties 30 sync committee.json
@@ -25583,6 +25583,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 30 attestation.json
@@ -8808,6 +8808,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 30 attestations 30 sync committees.json
@@ -9408,6 +9408,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 30 sync committee.json
@@ -8928,6 +8928,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 8 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 8 attestation.json
@@ -3968,6 +3968,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 8 attestations 8 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 8 attestations 8 sync committees.json
@@ -4128,6 +4128,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 8 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/1 duties 8 sync committee.json
@@ -4000,6 +4000,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 30 attestation.json
@@ -13981,6 +13981,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 30 attestations 30 sync committees.json
@@ -14581,6 +14581,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 30 sync committee.json
@@ -14101,6 +14101,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 8 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 8 attestation.json
@@ -6919,6 +6919,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 8 attestations 8 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 8 attestations 8 sync committees.json
@@ -7079,6 +7079,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 8 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/2 duties 8 sync committee.json
@@ -6951,6 +6951,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 30 attestation.json
@@ -24291,6 +24291,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 30 attestations 30 sync committees.json
@@ -24851,6 +24851,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 30 sync committee.json
@@ -24403,6 +24403,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 8 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 8 attestation.json
@@ -12821,6 +12821,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 8 attestations 8 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 8 attestations 8 sync committees.json
@@ -12981,6 +12981,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 8 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_different_validators/4 duties 8 sync committee.json
@@ -12853,6 +12853,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 1 attestation.json
@@ -2428,6 +2428,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 1 attestations 1 sync committees.json
@@ -2448,6 +2448,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 1 sync committee.json
@@ -2432,6 +2432,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 30 attestation.json
@@ -8808,6 +8808,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 30 attestations 30 sync committees.json
@@ -9408,6 +9408,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/1 duties 30 sync committee.json
@@ -8928,6 +8928,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 1 attestation.json
@@ -4690,6 +4690,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 1 attestations 1 sync committees.json
@@ -4730,6 +4730,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 1 sync committee.json
@@ -4698,6 +4698,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 30 attestation.json
@@ -14521,6 +14521,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 30 attestations 30 sync committees.json
@@ -15721,6 +15721,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/2 duties 30 sync committee.json
@@ -14761,6 +14761,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 1 attestation.json
@@ -9214,6 +9214,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 1 attestations 1 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 1 attestations 1 sync committees.json
@@ -9294,6 +9294,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 1 sync committee.json
@@ -9230,6 +9230,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 30 attestation.json
@@ -25947,6 +25947,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 30 attestations 30 sync committees.json
@@ -28347,6 +28347,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/shuffled_happy_flow_duties_with_same_validators/4 duties 30 sync committee.json
@@ -26427,6 +26427,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/1 attestation 1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/1 attestation 1 sync committee.json
@@ -563,6 +563,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/1 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/1 attestation.json
@@ -548,6 +548,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/1 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/1 sync committee.json
@@ -552,6 +552,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/30 attestation 30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/30 attestation 30 sync committee.json
@@ -7175,6 +7175,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/30 attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/30 attestation.json
@@ -6725,6 +6725,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/30 sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/start_duty/30 sync committee.json
@@ -6845,6 +6845,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/valid_beacon_vote/30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/valid_beacon_vote/30 attestations 30 sync committees.json
@@ -7643,6 +7643,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/wrong_beacon_vote/30 attestations 30 sync committees.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/wrong_beacon_vote/30 attestations 30 sync committees.json
@@ -7175,6 +7175,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/wrong_message_ID/attestation.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/wrong_message_ID/attestation.json
@@ -548,6 +548,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }

--- a/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/wrong_message_ID/sync committee.json
+++ b/ssv/spectest/generate/state_comparison/committee_MultiCommitteeSpecTest/wrong_message_ID/sync committee.json
@@ -552,6 +552,5 @@
 						],
 						"Graffiti": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 				}
-		},
-		"HighestDutySlotMap": null
+		}
 }


### PR DESCRIPTION
## Overview

This PR simply removes the leftover `HighestDutySlotMap` field from `CommitteeAlias` in `Committee`'s custom JSON marshalling function.