### PR TITLE
Drop unnecessary nolint comments

### DIFF
--- a/qbft/instance.go
+++ b/qbft/instance.go
@@ -67,11 +67,9 @@ func (i *Instance) Start(value []byte, height Height) {
 		// propose if this node is the proposer
 		if proposer(i.State, i.GetConfig(), FirstRound) == i.State.CommitteeMember.OperatorID {
 			proposal, err := CreateProposal(i.State, i.signer, i.StartValue, nil, nil)
-			// nolint
 			if err != nil {
 				fmt.Printf("%s\n", err.Error())
 			}
-			// nolint
 			if err := i.Broadcast(proposal); err != nil {
 				fmt.Printf("%s\n", err.Error())
 			}

--- a/qbft/timeout.go
+++ b/qbft/timeout.go
@@ -6,6 +6,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// At the moment, these variables are useful for the node implementation
+// TODO: It's usage should be updated in the PR https://github.com/ssvlabs/ssv-spec/pull/352
 var (
 	QuickTimeoutThreshold = Round(8)
 	QuickTimeout          = 2 * time.Second

--- a/qbft/timeout.go
+++ b/qbft/timeout.go
@@ -1,14 +1,15 @@
 package qbft
 
 import (
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 var (
-	quickTimeoutThreshold = Round(8)        //nolint
-	quickTimeout          = 2 * time.Second //nolint
-	slowTimeout           = 2 * time.Minute //nolint
+	QuickTimeoutThreshold = Round(8)
+	QuickTimeout          = 2 * time.Second
+	SlowTimeout           = 2 * time.Minute
 	// CutoffRound which round the instance should stop its timer and progress no further
 	CutoffRound = 12 // stop processing attestations after 8*2+120*3 = 6.2 min (~ 1 epoch)
 )

--- a/ssv/runner_validations.go
+++ b/ssv/runner_validations.go
@@ -50,7 +50,7 @@ func (b *BaseRunner) ValidatePostConsensusMsg(runner Runner, psigMsgs *types.Par
 	}
 
 	// TODO https://github.com/ssvlabs/ssv-spec/issues/142 need to fix with this issue solution instead.
-	if b.State.DecidedValue == nil || len(b.State.DecidedValue) == 0 {
+	if len(b.State.DecidedValue) == 0 {
 		return errors.New("no decided value")
 	}
 

--- a/ssv/spectest/tests/runner/duties/newduty/consensus_not_started.go
+++ b/ssv/spectest/tests/runner/duties/newduty/consensus_not_started.go
@@ -12,8 +12,6 @@ import (
 func ConsensusNotStarted() tests.SpecTest {
 	ks := testingutils.Testing4SharesSet()
 
-	// TODO: check error
-	// nolint
 	startRunner := func(r ssv.Runner, duty types.Duty) ssv.Runner {
 		r.GetBaseRunner().State = ssv.NewRunnerState(3, duty)
 		return r

--- a/ssv/spectest/tests/runner/duties/newduty/finished.go
+++ b/ssv/spectest/tests/runner/duties/newduty/finished.go
@@ -14,8 +14,6 @@ import (
 func Finished() tests.SpecTest {
 	ks := testingutils.Testing4SharesSet()
 
-	// TODO: check error
-	// nolint
 	finishRunner := func(r ssv.Runner, duty types.Duty, finishController bool) ssv.Runner {
 		r.GetBaseRunner().State = ssv.NewRunnerState(3, duty)
 

--- a/ssv/spectest/tests/runner/duties/newduty/not_decided.go
+++ b/ssv/spectest/tests/runner/duties/newduty/not_decided.go
@@ -16,8 +16,6 @@ import (
 func NotDecided() tests.SpecTest {
 	ks := testingutils.Testing4SharesSet()
 
-	// TODO: check error
-	// nolint
 	startRunner := func(r ssv.Runner, duty types.Duty) ssv.Runner {
 		r.GetBaseRunner().State = ssv.NewRunnerState(3, duty)
 		r.GetBaseRunner().State.RunningInstance = qbft.NewInstance(

--- a/ssv/spectest/tests/runner/duties/newduty/post_future_decided.go
+++ b/ssv/spectest/tests/runner/duties/newduty/post_future_decided.go
@@ -17,8 +17,6 @@ import (
 func PostFutureDecided() tests.SpecTest {
 	ks := testingutils.Testing4SharesSet()
 
-	// TODO: check error
-	// nolint
 	futureDecide := func(r ssv.Runner, duty types.Duty) ssv.Runner {
 		r.GetBaseRunner().State = ssv.NewRunnerState(3, duty)
 		r.GetBaseRunner().State.RunningInstance = qbft.NewInstance(

--- a/ssv/spectest/tests/runner/preconsensus/post_decided.go
+++ b/ssv/spectest/tests/runner/preconsensus/post_decided.go
@@ -16,8 +16,6 @@ import (
 func PostDecided() tests.SpecTest {
 	ks := testingutils.Testing4SharesSet()
 
-	// TODO: check errors
-	// nolint
 	decideRunner := func(r ssv.Runner, duty *types.ValidatorDuty, decidedValue *types.ValidatorConsensusData, preMsgs []*types.PartialSignatureMessages) ssv.Runner {
 		r.GetBaseRunner().State = ssv.NewRunnerState(3, duty)
 		for _, msg := range preMsgs {

--- a/ssv/spectest/tests/runner/preconsensus/post_finish.go
+++ b/ssv/spectest/tests/runner/preconsensus/post_finish.go
@@ -15,8 +15,6 @@ import (
 func PostFinish() tests.SpecTest {
 	ks := testingutils.Testing4SharesSet()
 
-	// TODO: check errors
-	// nolint
 	finishRunner := func(runner ssv.Runner, duty *types.ValidatorDuty) ssv.Runner {
 		runner.GetBaseRunner().State = ssv.NewRunnerState(3, duty)
 		runner.GetBaseRunner().State.Finished = true


### PR DESCRIPTION
# Overview

This PR drops unnecessary `nolint` comments.

There were lint errors related to the unused variables `quickTimeoutThreshold`, `quickTimeout` and `slowTimeout` in `timeout.go`. To resolve these errors while preserving their intended use as informative constants for implementation, these variables have been capitalised to make them exported (accessible outside their package), avoiding the lint errors.

Note: There are still `nolint` comments in `encryption.go` but the related function will be fixed in another PR.