### PR TITLE
Fix static analysis issues

### DIFF
--- a/qbft/spectest/generate/main.go
+++ b/qbft/spectest/generate/main.go
@@ -93,7 +93,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0444); err != nil {
+	if err := os.WriteFile(file, byts, 0400); err != nil {
 		panic(err.Error())
 	}
 }
@@ -120,7 +120,7 @@ func writeJson(data []byte) {
 
 	file := filepath.Join(basedir, "tests.json")
 	log.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0444); err != nil {
+	if err := os.WriteFile(file, data, 0400); err != nil {
 		panic(err.Error())
 	}
 }

--- a/qbft/spectest/generate/main.go
+++ b/qbft/spectest/generate/main.go
@@ -93,7 +93,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0600); err != nil {
+	if err := os.WriteFile(file, byts, 0444); err != nil {
 		panic(err.Error())
 	}
 }
@@ -120,7 +120,7 @@ func writeJson(data []byte) {
 
 	file := filepath.Join(basedir, "tests.json")
 	log.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0600); err != nil {
+	if err := os.WriteFile(file, data, 0444); err != nil {
 		panic(err.Error())
 	}
 }

--- a/qbft/spectest/generate/main.go
+++ b/qbft/spectest/generate/main.go
@@ -3,15 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/ssvlabs/ssv-spec/qbft/spectest/tests"
-	comparable2 "github.com/ssvlabs/ssv-spec/types/testingutils/comparable"
 	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/ssvlabs/ssv-spec/qbft/spectest/tests"
+	comparable2 "github.com/ssvlabs/ssv-spec/types/testingutils/comparable"
 
 	"github.com/ssvlabs/ssv-spec/qbft/spectest"
 )
@@ -92,7 +93,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0644); err != nil {
+	if err := os.WriteFile(file, byts, 0600); err != nil {
 		panic(err.Error())
 	}
 }
@@ -119,7 +120,7 @@ func writeJson(data []byte) {
 
 	file := filepath.Join(basedir, "tests.json")
 	log.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0644); err != nil {
+	if err := os.WriteFile(file, data, 0600); err != nil {
 		panic(err.Error())
 	}
 }

--- a/qbft/spectest/tests/controller_spectest.go
+++ b/qbft/spectest/tests/controller_spectest.go
@@ -209,7 +209,7 @@ func (test *ControllerSpecTest) overrideStateComparison(t *testing.T) {
 	basedir = filepath.Join(basedir, "generate")
 	dir := typescomparable.GetSCDir(basedir, reflect.TypeOf(test).String())
 	path := filepath.Join(dir, fmt.Sprintf("%s.json", test.TestName()))
-	byteValue, err := os.ReadFile(path)
+	byteValue, err := os.ReadFile(filepath.Clean(path))
 	require.NoError(t, err)
 	sc := make([]*qbft.Controller, len(test.RunInstanceData))
 	require.NoError(t, json.Unmarshal(byteValue, &sc))

--- a/ssv/runner_validations.go
+++ b/ssv/runner_validations.go
@@ -50,7 +50,7 @@ func (b *BaseRunner) ValidatePostConsensusMsg(runner Runner, psigMsgs *types.Par
 	}
 
 	// TODO https://github.com/ssvlabs/ssv-spec/issues/142 need to fix with this issue solution instead.
-	if b.State.DecidedValue == nil || len(b.State.DecidedValue) == 0 {
+	if len(b.State.DecidedValue) == 0 {
 		return errors.New("no decided value")
 	}
 

--- a/ssv/spectest/generate/main.go
+++ b/ssv/spectest/generate/main.go
@@ -113,7 +113,7 @@ func writeSingleSCJson(path string, testType string, post interface{}) {
 	}
 
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0600); err != nil {
+	if err := os.WriteFile(file, byts, 0444); err != nil {
 		panic(err.Error())
 	}
 }
@@ -157,7 +157,7 @@ func writeJson(data []byte) {
 	}
 
 	// Write the gzipped data to a file
-	if err := os.WriteFile(file, buf.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(file, buf.Bytes(), 0444); err != nil {
 		panic(err.Error())
 	}
 }

--- a/ssv/spectest/generate/main.go
+++ b/ssv/spectest/generate/main.go
@@ -113,7 +113,7 @@ func writeSingleSCJson(path string, testType string, post interface{}) {
 	}
 
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0444); err != nil {
+	if err := os.WriteFile(file, byts, 0400); err != nil {
 		panic(err.Error())
 	}
 }
@@ -157,7 +157,7 @@ func writeJson(data []byte) {
 	}
 
 	// Write the gzipped data to a file
-	if err := os.WriteFile(file, buf.Bytes(), 0444); err != nil {
+	if err := os.WriteFile(file, buf.Bytes(), 0400); err != nil {
 		panic(err.Error())
 	}
 }

--- a/ssv/spectest/generate/main.go
+++ b/ssv/spectest/generate/main.go
@@ -5,16 +5,17 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
-	"github.com/ssvlabs/ssv-spec/types"
-	comparable2 "github.com/ssvlabs/ssv-spec/types/testingutils/comparable"
 	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
+	"github.com/ssvlabs/ssv-spec/types"
+	comparable2 "github.com/ssvlabs/ssv-spec/types/testingutils/comparable"
 
 	"github.com/ssvlabs/ssv-spec/ssv/spectest"
 )
@@ -112,7 +113,7 @@ func writeSingleSCJson(path string, testType string, post interface{}) {
 	}
 
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0644); err != nil {
+	if err := os.WriteFile(file, byts, 0600); err != nil {
 		panic(err.Error())
 	}
 }
@@ -156,7 +157,7 @@ func writeJson(data []byte) {
 	}
 
 	// Write the gzipped data to a file
-	if err := os.WriteFile(file, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(file, buf.Bytes(), 0600); err != nil {
 		panic(err.Error())
 	}
 }

--- a/types/spectest/generate/main.go
+++ b/types/spectest/generate/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ssvlabs/ssv-spec/types/spectest"
-	comparable2 "github.com/ssvlabs/ssv-spec/types/testingutils/comparable"
 	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
+
+	"github.com/ssvlabs/ssv-spec/types/spectest"
+	comparable2 "github.com/ssvlabs/ssv-spec/types/testingutils/comparable"
 )
 
 //go:generate go run main.go
@@ -81,7 +82,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0644); err != nil {
+	if err := os.WriteFile(file, byts, 0600); err != nil {
 		panic(err.Error())
 	}
 }
@@ -108,7 +109,7 @@ func writeJson(data []byte) {
 	file := filepath.Join(basedir, "tests.json")
 
 	fmt.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0644); err != nil {
+	if err := os.WriteFile(file, data, 0600); err != nil {
 		panic(err.Error())
 	}
 }

--- a/types/spectest/generate/main.go
+++ b/types/spectest/generate/main.go
@@ -82,7 +82,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0600); err != nil {
+	if err := os.WriteFile(file, byts, 0444); err != nil {
 		panic(err.Error())
 	}
 }
@@ -109,7 +109,7 @@ func writeJson(data []byte) {
 	file := filepath.Join(basedir, "tests.json")
 
 	fmt.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0600); err != nil {
+	if err := os.WriteFile(file, data, 0444); err != nil {
 		panic(err.Error())
 	}
 }

--- a/types/spectest/generate/main.go
+++ b/types/spectest/generate/main.go
@@ -82,7 +82,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0444); err != nil {
+	if err := os.WriteFile(file, byts, 0400); err != nil {
 		panic(err.Error())
 	}
 }
@@ -109,7 +109,7 @@ func writeJson(data []byte) {
 	file := filepath.Join(basedir, "tests.json")
 
 	fmt.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0444); err != nil {
+	if err := os.WriteFile(file, data, 0400); err != nil {
 		panic(err.Error())
 	}
 }

--- a/types/testingutils/comparable/helpers.go
+++ b/types/testingutils/comparable/helpers.go
@@ -3,15 +3,16 @@ package comparable
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	spec2 "github.com/attestantio/go-eth2-client/spec"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/google/go-cmp/cmp"
 	"github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 func NoErrorEncoding(obj ssz.Marshaler) []byte {
@@ -46,7 +47,8 @@ func UnmarshalStateComparison[T types.Root](basedir string, testName string, tes
 	basedir = filepath.Join(basedir, "generate")
 	scDir := GetSCDir(basedir, testType)
 	path := filepath.Join(scDir, fmt.Sprintf("%s.json", testName))
-	byteValue, err := os.ReadFile(path)
+
+	byteValue, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nilT, err
 	}
@@ -64,7 +66,7 @@ func readStateComparison(basedir string, testName string, testType string) (map[
 	basedir = filepath.Join(basedir, "generate")
 	scDir := GetSCDir(basedir, testType)
 	path := filepath.Join(scDir, fmt.Sprintf("%s.json", testName))
-	byteValue, err := os.ReadFile(path)
+	byteValue, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/types/testingutils/shuffle.go
+++ b/types/testingutils/shuffle.go
@@ -28,7 +28,7 @@ func getNonEmptyListsIndices(lists [][]interface{}) []int {
 func MergeListsWithRandomPick(lists [][]interface{}) []interface{} {
 
 	seed := int64(42)
-	rand := rand.New(rand.NewSource(seed))
+	rand := rand.New(rand.NewSource(seed)) // #nosec G404 --This PRNG is only used for testing. No cryptographically secure one allows seeding, which is useful so tests won't change
 	result := make([]interface{}, 0)
 
 	// Continue until all lists are empty


### PR DESCRIPTION
# Overview

This PR adds fixes for static analysis issues including:
- file permission issues
- file inclusion via variable issues

It also adds a `nosec` comment for a cryptographically insecure PRNG (pseudo-random number generator) used in tests. We use this PRNG (`math/rand`) since the secure `crypto/rand` doesn't allow seeding (which is important for consistent tests).

An existing issue with implicit memory aliasing in a for loop will be automatically fixed by the go update to 1.22.