### PR TITLE
Add mekong testnet

### DIFF
--- a/types/beacon_types.go
+++ b/types/beacon_types.go
@@ -158,6 +158,9 @@ const (
 	// PraterNetwork represents the Prater test network.
 	PraterNetwork BeaconNetwork = "prater"
 
+	// MekongNetwork represents the Mekong test network.
+	MekongNetwork BeaconNetwork = "mekong"
+
 	// BeaconTestNetwork is a simple test network with a custom genesis time
 	BeaconTestNetwork BeaconNetwork = "now_test_network"
 )
@@ -174,6 +177,8 @@ func NetworkFromString(n string) BeaconNetwork {
 		return HoleskyNetwork
 	case string(PraterNetwork):
 		return PraterNetwork
+	case string(MekongNetwork):
+		return MekongNetwork
 	case string(BeaconTestNetwork):
 		return BeaconTestNetwork
 	default:
@@ -190,6 +195,8 @@ func (n BeaconNetwork) ForkVersion() [4]byte {
 		return [4]byte{0x01, 0x01, 0x70, 0x00}
 	case PraterNetwork:
 		return [4]byte{0x00, 0x00, 0x10, 0x20}
+	case MekongNetwork:
+		return [4]byte{0x10, 0x63, 0x76, 0x24}
 	case BeaconTestNetwork:
 		return [4]byte{0x99, 0x99, 0x99, 0x99}
 	default:
@@ -206,6 +213,8 @@ func (n BeaconNetwork) MinGenesisTime() uint64 {
 		return 1695902400
 	case PraterNetwork:
 		return 1616508000
+	case MekongNetwork:
+		return 1730822340
 	case BeaconTestNetwork:
 		return 1616508000
 	default:


### PR DESCRIPTION
## Overview

This PR adds the Mekong testnet as a `BeaconNetwork`.