### PR TITLE
Stateless proposer function

### DIFF
--- a/qbft/round_robin_proposer.go
+++ b/qbft/round_robin_proposer.go
@@ -6,12 +6,13 @@ import "github.com/ssvlabs/ssv-spec/types"
 // Each new height starts with the first proposer and increments by 1 with each following round.
 // Each new height has a different first round proposer which is +1 from the previous height.
 // First height starts with index 0
-func RoundRobinProposer(state *State, round Round) types.OperatorID {
+// Assumption: the operators list is sorted.
+func RoundRobinProposer(height Height, round Round, operators []types.OperatorID) types.OperatorID {
 	firstRoundIndex := 0
-	if state.Height != FirstHeight {
-		firstRoundIndex += int(state.Height) % len(state.CommitteeMember.Committee)
+	if height != FirstHeight {
+		firstRoundIndex += int(height) % len(operators)
 	}
 
-	index := (firstRoundIndex + int(round) - int(FirstRound)) % len(state.CommitteeMember.Committee)
-	return state.CommitteeMember.Committee[index].OperatorID
+	index := (firstRoundIndex + int(round) - int(FirstRound)) % len(operators)
+	return operators[index]
 }

--- a/qbft/spectest/tests/round_robin_spectest.go
+++ b/qbft/spectest/tests/round_robin_spectest.go
@@ -1,10 +1,11 @@
 package tests
 
 import (
+	"testing"
+
 	"github.com/ssvlabs/ssv-spec/qbft"
 	"github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type RoundRobinSpecTest struct {
@@ -19,13 +20,13 @@ func (test *RoundRobinSpecTest) Run(t *testing.T) {
 	require.True(t, len(test.Heights) > 0)
 	for i, h := range test.Heights {
 		r := test.Rounds[i]
-		s := &qbft.State{
-			Height:          h,
-			Round:           r,
-			CommitteeMember: test.Share,
+
+		operators := make([]types.OperatorID, 0)
+		for _, operator := range test.Share.Committee {
+			operators = append(operators, operator.OperatorID)
 		}
 
-		require.EqualValues(t, test.Proposers[i], qbft.RoundRobinProposer(s, r))
+		require.EqualValues(t, test.Proposers[i], qbft.RoundRobinProposer(h, r, operators))
 	}
 }
 


### PR DESCRIPTION
## Overview

This PR makes the `RoundRobinProposer` function stateless by passing as arguments the height and list of operators instead of a state.