### PR TITLE
fix json generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 ## IDE
 .idea
 .DS_Store
+.vscode
 
 # binaries
 .bin

--- a/qbft/spectest/generate/main.go
+++ b/qbft/spectest/generate/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -18,6 +17,9 @@ import (
 )
 
 //go:generate go run main.go
+
+var testsDir = "tests"
+var stateComparisonDir = "state_comparison"
 
 func main() {
 	clearStateComparisonFolder()
@@ -38,13 +40,6 @@ func main() {
 		log.Fatalf("did not generate all tests\n")
 	}
 
-	// write small json files for each test
-	// try to create directory if it doesn't exist
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		log.Fatalf("no caller info")
-	}
-	testsDir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "tests")
 	if err := os.MkdirAll(testsDir, 0700); err != nil && !os.IsExist(err) {
 		panic(err.Error())
 	}
@@ -55,7 +50,7 @@ func main() {
 		}
 		name = strings.ReplaceAll(name, " ", "_")
 		name = strings.ReplaceAll(name, "*", "")
-		name = "tests/" + name
+		name = filepath.Join(testsDir, name)
 		writeJson(name, byts)
 	}
 
@@ -64,7 +59,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	writeJson("tests", byts)
+	writeJson(testsDir, byts)
 
 	// write state comparison json files
 	for _, testF := range spectest.AllTests {
@@ -79,33 +74,21 @@ func main() {
 }
 
 func clearStateComparisonFolder() {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	dir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "state_comparison")
-
-	if err := os.RemoveAll(dir); err != nil {
+	if err := os.RemoveAll(stateComparisonDir); err != nil {
 		panic(err.Error())
 	}
 
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(stateComparisonDir, 0700); err != nil {
 		panic(err.Error())
 	}
 }
 
 func clearTestsFolder() {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	dir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "tests")
-
-	if err := os.RemoveAll(dir); err != nil {
+	if err := os.RemoveAll(testsDir); err != nil {
 		panic(err.Error())
 	}
 
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(testsDir, 0700); err != nil {
 		panic(err.Error())
 	}
 }
@@ -136,26 +119,11 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 }
 
 func scDir(testType string) string {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	basedir = strings.TrimSuffix(basedir, "main.go")
-	scDir := comparable2.GetSCDir(basedir, testType)
-	return scDir
+	return comparable2.GetSCDir(".", testType)
 }
 
 func writeJson(name string, data []byte) {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	basedir = strings.TrimSuffix(basedir, "main.go")
-
-	// try to create directory if it doesn't exist
-	_ = os.Mkdir(basedir, os.ModeDir)
-
-	file := filepath.Join(basedir, name+".json")
+	file := name + ".json"
 	log.Printf("writing spec tests json to: %s\n", file)
 	if err := os.WriteFile(file, data, 0400); err != nil {
 		panic(err.Error())

--- a/qbft/spectest/generate/main.go
+++ b/qbft/spectest/generate/main.go
@@ -113,7 +113,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0400); err != nil {
+	if err := os.WriteFile(file, byts, 0664); err != nil {
 		panic(err.Error())
 	}
 }
@@ -125,7 +125,7 @@ func scDir(testType string) string {
 func writeJson(name string, data []byte) {
 	file := name + ".json"
 	log.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0400); err != nil {
+	if err := os.WriteFile(file, data, 0664); err != nil {
 		panic(err.Error())
 	}
 }

--- a/ssv/spectest/generate/main.go
+++ b/ssv/spectest/generate/main.go
@@ -126,7 +126,7 @@ func writeSingleSCJson(path string, testType string, post interface{}) {
 	}
 
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0400); err != nil {
+	if err := os.WriteFile(file, byts, 0664); err != nil {
 		panic(err.Error())
 	}
 }
@@ -138,7 +138,7 @@ func scDir(testType string) string {
 func writeJson(name string, data []byte) {
 	file := name + ".json"
 	log.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0400); err != nil {
+	if err := os.WriteFile(file, data, 0664); err != nil {
 		panic(err.Error())
 	}
 }

--- a/ssv/spectest/generate/main.go
+++ b/ssv/spectest/generate/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -38,13 +37,7 @@ func main() {
 		log.Fatalf("did not generate all tests\n")
 	}
 
-	// write small json files for each test
-	// try to create directory if it doesn't exist
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		log.Fatalf("no caller info")
-	}
-	testsDir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "tests")
+	testsDir := "tests"
 	if err := os.MkdirAll(testsDir, 0700); err != nil && !os.IsExist(err) {
 		panic(err.Error())
 	}
@@ -80,11 +73,7 @@ func main() {
 }
 
 func clearStateComparisonFolder() {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	dir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "state_comparison")
+	dir := "state_comparison"
 
 	if err := os.RemoveAll(dir); err != nil {
 		panic(err.Error())
@@ -109,11 +98,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 }
 
 func clearTestsFolder() {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	dir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "tests")
+	dir := "tests"
 
 	if err := os.RemoveAll(dir); err != nil {
 		panic(err.Error())
@@ -149,26 +134,12 @@ func writeSingleSCJson(path string, testType string, post interface{}) {
 }
 
 func scDir(testType string) string {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	basedir = strings.TrimSuffix(basedir, "main.go")
-	scDir := comparable2.GetSCDir(basedir, testType)
+	scDir := comparable2.GetSCDir(".", testType)
 	return scDir
 }
 
 func writeJson(name string, data []byte) {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	basedir = strings.TrimSuffix(basedir, "main.go")
-
-	// try to create directory if it doesn't exist
-	_ = os.Mkdir(basedir, os.ModeDir)
-
-	file := filepath.Join(basedir, name+".json")
+	file := filepath.Join(".", name+".json")
 	log.Printf("writing spec tests json to: %s\n", file)
 	if err := os.WriteFile(file, data, 0400); err != nil {
 		panic(err.Error())

--- a/ssv/spectest/generate/main.go
+++ b/ssv/spectest/generate/main.go
@@ -19,6 +19,9 @@ import (
 
 //go:generate go run main.go
 
+var testsDir = "tests"
+var stateComparisonDir = "state_comparison"
+
 func main() {
 	clearStateComparisonFolder()
 	clearTestsFolder()
@@ -37,7 +40,6 @@ func main() {
 		log.Fatalf("did not generate all tests\n")
 	}
 
-	testsDir := "tests"
 	if err := os.MkdirAll(testsDir, 0700); err != nil && !os.IsExist(err) {
 		panic(err.Error())
 	}
@@ -48,7 +50,7 @@ func main() {
 		}
 		name = strings.ReplaceAll(name, " ", "_")
 		name = strings.ReplaceAll(name, "*", "")
-		name = "tests/" + name
+		name = filepath.Join(testsDir, name)
 		writeJson(name, byts)
 	}
 
@@ -57,7 +59,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	writeJson("tests", byts)
+	writeJson(testsDir, byts)
 
 	// write state comparison json files
 	for _, testF := range spectest.AllTests {
@@ -73,13 +75,11 @@ func main() {
 }
 
 func clearStateComparisonFolder() {
-	dir := "state_comparison"
-
-	if err := os.RemoveAll(dir); err != nil {
+	if err := os.RemoveAll(stateComparisonDir); err != nil {
 		panic(err.Error())
 	}
 
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(stateComparisonDir, 0700); err != nil {
 		panic(err.Error())
 	}
 }
@@ -98,13 +98,11 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 }
 
 func clearTestsFolder() {
-	dir := "tests"
-
-	if err := os.RemoveAll(dir); err != nil {
+	if err := os.RemoveAll(testsDir); err != nil {
 		panic(err.Error())
 	}
 
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(testsDir, 0700); err != nil {
 		panic(err.Error())
 	}
 }
@@ -134,12 +132,11 @@ func writeSingleSCJson(path string, testType string, post interface{}) {
 }
 
 func scDir(testType string) string {
-	scDir := comparable2.GetSCDir(".", testType)
-	return scDir
+	return comparable2.GetSCDir(".", testType)
 }
 
 func writeJson(name string, data []byte) {
-	file := filepath.Join(".", name+".json")
+	file := name + ".json"
 	log.Printf("writing spec tests json to: %s\n", file)
 	if err := os.WriteFile(file, data, 0400); err != nil {
 		panic(err.Error())

--- a/types/spectest/generate/main.go
+++ b/types/spectest/generate/main.go
@@ -103,7 +103,7 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 
 	file := filepath.Join(scDir, fmt.Sprintf("%s.json", name))
 	log.Printf("writing state comparison json: %s\n", file)
-	if err := os.WriteFile(file, byts, 0400); err != nil {
+	if err := os.WriteFile(file, byts, 0664); err != nil {
 		panic(err.Error())
 	}
 }
@@ -115,7 +115,7 @@ func scDir(testType string) string {
 func writeJson(name string, data []byte) {
 	file := name + ".json"
 	log.Printf("writing spec tests json to: %s\n", file)
-	if err := os.WriteFile(file, data, 0400); err != nil {
+	if err := os.WriteFile(file, data, 0664); err != nil {
 		panic(err.Error())
 	}
 }

--- a/types/spectest/generate/main.go
+++ b/types/spectest/generate/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/ssvlabs/ssv-spec/types/spectest"
@@ -15,6 +14,9 @@ import (
 )
 
 //go:generate go run main.go
+
+var testsDir = "tests"
+var stateComparisonDir = "state_comparison"
 
 func main() {
 	clearStateComparisonFolder()
@@ -33,13 +35,6 @@ func main() {
 		log.Fatalf("did not generate all tests\n")
 	}
 
-	// write small json files for each test
-	// try to create directory if it doesn't exist
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		log.Fatalf("no caller info")
-	}
-	testsDir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "tests")
 	if err := os.MkdirAll(testsDir, 0700); err != nil && !os.IsExist(err) {
 		panic(err.Error())
 	}
@@ -50,7 +45,7 @@ func main() {
 		}
 		name = strings.ReplaceAll(name, " ", "_")
 		name = strings.ReplaceAll(name, "*", "")
-		name = "tests/" + name
+		name = filepath.Join(testsDir, name)
 		writeJson(name, byts)
 	}
 
@@ -59,7 +54,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	writeJson("tests", byts)
+	writeJson(testsDir, byts)
 
 	// write state comparison json files
 	for _, testF := range spectest.AllTests {
@@ -69,33 +64,21 @@ func main() {
 }
 
 func clearStateComparisonFolder() {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	dir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "state_comparison")
-
-	if err := os.RemoveAll(dir); err != nil {
+	if err := os.RemoveAll(stateComparisonDir); err != nil {
 		panic(err.Error())
 	}
 
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(stateComparisonDir, 0700); err != nil {
 		panic(err.Error())
 	}
 }
 
 func clearTestsFolder() {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	dir := filepath.Join(strings.TrimSuffix(basedir, "main.go"), "tests")
-
-	if err := os.RemoveAll(dir); err != nil {
+	if err := os.RemoveAll(testsDir); err != nil {
 		panic(err.Error())
 	}
 
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(testsDir, 0700); err != nil {
 		panic(err.Error())
 	}
 }
@@ -126,26 +109,11 @@ func writeJsonStateComparison(name, testType string, post interface{}) {
 }
 
 func scDir(testType string) string {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	basedir = strings.TrimSuffix(basedir, "main.go")
-	scDir := comparable2.GetSCDir(basedir, testType)
-	return scDir
+	return comparable2.GetSCDir(".", testType)
 }
 
 func writeJson(name string, data []byte) {
-	_, basedir, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("no caller info")
-	}
-	basedir = strings.TrimSuffix(basedir, "main.go")
-
-	// try to create directory if it doesn't exist
-	_ = os.Mkdir(basedir, os.ModeDir)
-
-	file := filepath.Join(basedir, name+".json")
+	file := name + ".json"
 	log.Printf("writing spec tests json to: %s\n", file)
 	if err := os.WriteFile(file, data, 0400); err != nil {
 		panic(err.Error())


### PR DESCRIPTION
After recent change in spec, we need to run `go generate` to get tests.json file used for testing in ssv. But because of `runtime.Caller(0)` generating json outside the repo is impossible. Whit this proposed change we can run it in any directory, where the binary used for generating code is located 