### PR TITLE
preconfs: preconf-commitment duty

### DIFF
--- a/types/beacon_types.go
+++ b/types/beacon_types.go
@@ -23,6 +23,7 @@ var (
 	DomainSyncCommitteeSelectionProof = [4]byte{0x08, 0x00, 0x00, 0x00}
 	DomainContributionAndProof        = [4]byte{0x09, 0x00, 0x00, 0x00}
 	DomainApplicationBuilder          = [4]byte{0x00, 0x00, 0x00, 0x01}
+	PreconfCommitment                 = [4]byte{0x00, 0x00, 0x00, 0x02}
 
 	DomainError = [4]byte{0x99, 0x99, 0x99, 0x99}
 )
@@ -49,6 +50,8 @@ const (
 	BNRoleValidatorRegistration
 	BNRoleVoluntaryExit
 
+	BNRolePreconfCommitment
+
 	BNRoleUnknown = math.MaxUint64
 )
 
@@ -69,6 +72,8 @@ func (r BeaconRole) String() string {
 		return "VALIDATOR_REGISTRATION"
 	case BNRoleVoluntaryExit:
 		return "VOLUNTARY_EXIT"
+	case BNRolePreconfCommitment:
+		return "PRECONF_COMMITMENT"
 	default:
 		return "UNDEFINED"
 	}
@@ -115,6 +120,8 @@ func MapDutyToRunnerRole(dutyRole BeaconRole) RunnerRole {
 		return RoleValidatorRegistration
 	case BNRoleVoluntaryExit:
 		return RoleVoluntaryExit
+	case BNRolePreconfCommitment:
+		return RolePreconfCommitment
 	}
 	return RoleUnknown
 }

--- a/types/consensus_data.go
+++ b/types/consensus_data.go
@@ -184,6 +184,8 @@ func (cid *ValidatorConsensusData) Validate() error {
 		return errors.New("validator registration has no consensus data")
 	case BNRoleVoluntaryExit:
 		return errors.New("voluntary exit has no consensus data")
+	case BNRolePreconfCommitment:
+		return errors.New("preconf commitment has no consensus data")
 	default:
 		return errors.New("unknown duty role")
 	}

--- a/types/partial_sig_message.go
+++ b/types/partial_sig_message.go
@@ -20,6 +20,8 @@ const (
 	ValidatorRegistrationPartialSig
 	// VoluntaryExitPartialSig is a partial signature over a VoluntaryExit object
 	VoluntaryExitPartialSig
+	// PreconfCommitmentPartialSig is a partial signature over a PreconfCommitment object
+	PreconfCommitmentPartialSig
 )
 
 type PartialSignatureMessages struct {

--- a/types/runner_role.go
+++ b/types/runner_role.go
@@ -12,6 +12,8 @@ const (
 	RoleValidatorRegistration
 	RoleVoluntaryExit
 
+	RolePreconfCommitment
+
 	RoleUnknown = -1
 )
 
@@ -30,6 +32,8 @@ func (r RunnerRole) String() string {
 		return "VALIDATOR_REGISTRATION_RUNNER"
 	case RoleVoluntaryExit:
 		return "VOLUNTARY_EXIT_RUNNER"
+	case RolePreconfCommitment:
+		return "PRECONF_COMMITMENT_RUNNER"
 	default:
 		return "UNDEFINED"
 	}


### PR DESCRIPTION
This PR defines the necessary primitives we need for preconf-commitment duty (Ethereum pre-confirmations) - corresponding PR in ssv repo is https://github.com/ssvlabs/ssv/pull/2063