### PR TITLE
Fix CreateMsgSpecTest Round Usage

### DIFF
--- a/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create commit.json
+++ b/qbft/spectest/generate/state_comparison/tests_CreateMsgSpecTest/qbft create message create commit.json
@@ -39,6 +39,6 @@
 		"RoundChangeJustifications": null,
 		"PrepareJustifications": null,
 		"CreateType": "CreateCommit",
-		"ExpectedRoot": "22763e542ac1faba4c01c9aefee5b96dc23889c1fb079e46e00a13c9fcc367c7",
+		"ExpectedRoot": "9ca79f5875b289eb3cbb318db864d9afb5c7cb2d5e48722137e7df6d3df1b0d5",
 		"ExpectedError": ""
 }

--- a/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_commit.json
+++ b/qbft/spectest/generate/tests/tests.CreateMsgSpecTest_qbft_create_message_create_commit.json
@@ -39,6 +39,6 @@
   "RoundChangeJustifications": null,
   "PrepareJustifications": null,
   "CreateType": "CreateCommit",
-  "ExpectedRoot": "22763e542ac1faba4c01c9aefee5b96dc23889c1fb079e46e00a13c9fcc367c7",
+  "ExpectedRoot": "9ca79f5875b289eb3cbb318db864d9afb5c7cb2d5e48722137e7df6d3df1b0d5",
   "ExpectedError": ""
 }

--- a/qbft/spectest/tests/create_message_spectest.go
+++ b/qbft/spectest/tests/create_message_spectest.go
@@ -80,6 +80,7 @@ func (test *CreateMsgSpecTest) createCommit() (*types.SignedSSVMessage, error) {
 	state := &qbft.State{
 		CommitteeMember: testingutils.TestingCommitteeMember(ks),
 		ID:              []byte{1, 2, 3, 4},
+		Round:           test.Round,
 	}
 	signer := testingutils.TestingOperatorSigner(ks)
 
@@ -91,6 +92,7 @@ func (test *CreateMsgSpecTest) createPrepare() (*types.SignedSSVMessage, error) 
 	state := &qbft.State{
 		CommitteeMember: testingutils.TestingCommitteeMember(ks),
 		ID:              []byte{1, 2, 3, 4},
+		Round:           test.Round,
 	}
 	signer := testingutils.TestingOperatorSigner(ks)
 
@@ -102,6 +104,7 @@ func (test *CreateMsgSpecTest) createProposal() (*types.SignedSSVMessage, error)
 	state := &qbft.State{
 		CommitteeMember: testingutils.TestingCommitteeMember(ks),
 		ID:              []byte{1, 2, 3, 4},
+		Round:           test.Round,
 	}
 	signer := testingutils.TestingOperatorSigner(ks)
 
@@ -115,6 +118,7 @@ func (test *CreateMsgSpecTest) createRoundChange() (*types.SignedSSVMessage, err
 		CommitteeMember:  testingutils.TestingCommitteeMember(ks),
 		ID:               []byte{1, 2, 3, 4},
 		PrepareContainer: qbft.NewMsgContainer(),
+		Round:            test.Round,
 	}
 	signer := testingutils.TestingOperatorSigner(ks)
 

--- a/qbft/spectest/tests/messages/create_commit.go
+++ b/qbft/spectest/tests/messages/create_commit.go
@@ -9,6 +9,6 @@ func CreateCommit() tests.SpecTest {
 		Name:         "create commit",
 		Value:        [32]byte{1, 2, 3, 4},
 		Round:        10,
-		ExpectedRoot: "22763e542ac1faba4c01c9aefee5b96dc23889c1fb079e46e00a13c9fcc367c7",
+		ExpectedRoot: "9ca79f5875b289eb3cbb318db864d9afb5c7cb2d5e48722137e7df6d3df1b0d5",
 	}
 }

--- a/ssv/runner.go
+++ b/ssv/runner.go
@@ -2,7 +2,6 @@ package ssv
 
 import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
 	"github.com/ssvlabs/ssv-spec/qbft"
@@ -35,32 +34,32 @@ type Runner interface {
 	ProcessPostConsensus(signedMsg *types.PartialSignatureMessages) error
 
 	// expectedPreConsensusRootsAndDomain an INTERNAL function, returns the expected pre-consensus roots to sign
-	expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, spec.DomainType, error)
+	expectedPreConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error)
 	// expectedPostConsensusRootsAndDomain an INTERNAL function, returns the expected post-consensus roots to sign
-	expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, spec.DomainType, error)
+	expectedPostConsensusRootsAndDomain() ([]ssz.HashRoot, phase0.DomainType, error)
 	// executeDuty an INTERNAL function, executes a duty.
 	executeDuty(duty types.Duty) error
 }
 
 type BaseRunner struct {
 	State          *State
-	Share          map[spec.ValidatorIndex]*types.Share
+	Share          map[phase0.ValidatorIndex]*types.Share
 	QBFTController *qbft.Controller
 	BeaconNetwork  types.BeaconNetwork
 	RunnerRoleType types.RunnerRole
 	*types.OperatorSigner
 
 	// highestDecidedSlot holds the highest decided duty slot and gets updated after each decided is reached
-	highestDecidedSlot spec.Slot
+	highestDecidedSlot phase0.Slot
 }
 
 func NewBaseRunner(
 	state *State,
-	share map[spec.ValidatorIndex]*types.Share,
+	share map[phase0.ValidatorIndex]*types.Share,
 	controller *qbft.Controller,
 	beaconNetwork types.BeaconNetwork,
 	runnerRoleType types.RunnerRole,
-	highestDecidedSlot spec.Slot,
+	highestDecidedSlot phase0.Slot,
 ) *BaseRunner {
 	return &BaseRunner{
 		State:              state,
@@ -73,7 +72,7 @@ func NewBaseRunner(
 }
 
 // SetHighestDecidedSlot set highestDecidedSlot for base runner
-func (b *BaseRunner) SetHighestDecidedSlot(slot spec.Slot) {
+func (b *BaseRunner) SetHighestDecidedSlot(slot phase0.Slot) {
 	b.highestDecidedSlot = slot
 }
 

--- a/ssv/spectest/tests/valcheck/valcheckattestations/majority_slashable.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/majority_slashable.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
 	"github.com/ssvlabs/ssv-spec/types"
@@ -15,11 +14,11 @@ import (
 func MajoritySlashable() tests.SpecTest {
 	data := &types.BeaconVote{
 		BlockRoot: testingutils.TestingBlockRoot,
-		Source: &spec.Checkpoint{
+		Source: &phase0.Checkpoint{
 			Epoch: 0,
 			Root:  testingutils.TestingBlockRoot,
 		},
-		Target: &spec.Checkpoint{
+		Target: &phase0.Checkpoint{
 			Epoch: 1,
 			Root:  testingutils.TestingBlockRoot,
 		},

--- a/ssv/spectest/tests/valcheck/valcheckattestations/minority_slashable.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/minority_slashable.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
 	"github.com/ssvlabs/ssv-spec/types"
@@ -15,11 +14,11 @@ import (
 func MinoritySlashable() tests.SpecTest {
 	data := &types.BeaconVote{
 		BlockRoot: testingutils.TestingBlockRoot,
-		Source: &spec.Checkpoint{
+		Source: &phase0.Checkpoint{
 			Epoch: 0,
 			Root:  testingutils.TestingBlockRoot,
 		},
-		Target: &spec.Checkpoint{
+		Target: &phase0.Checkpoint{
 			Epoch: 1,
 			Root:  testingutils.TestingBlockRoot,
 		},

--- a/ssv/spectest/tests/valcheck/valcheckattestations/slashable.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/slashable.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
 	"github.com/ssvlabs/ssv-spec/types"
@@ -14,14 +13,14 @@ import (
 // Slashable tests a slashable AttestationData
 func Slashable() tests.SpecTest {
 	data := &types.BeaconVote{
-		BlockRoot: spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
-		Source: &spec.Checkpoint{
+		BlockRoot: phase0.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+		Source: &phase0.Checkpoint{
 			Epoch: 0,
-			Root:  spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+			Root:  phase0.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
 		},
-		Target: &spec.Checkpoint{
+		Target: &phase0.Checkpoint{
 			Epoch: 1,
-			Root:  spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+			Root:  phase0.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
 		},
 	}
 

--- a/ssv/spectest/tests/valcheck/valcheckattestations/valid_non_slashable_slot.go
+++ b/ssv/spectest/tests/valcheck/valcheckattestations/valid_non_slashable_slot.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests"
 	"github.com/ssvlabs/ssv-spec/ssv/spectest/tests/valcheck"
 	"github.com/ssvlabs/ssv-spec/types"
@@ -14,14 +13,14 @@ import (
 // ValidNonSlashableSlot tests a valid AttestationData with a slot that is not slashable
 func ValidNonSlashableSlot() tests.SpecTest {
 	data := &types.BeaconVote{
-		BlockRoot: spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
-		Source: &spec.Checkpoint{
+		BlockRoot: phase0.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+		Source: &phase0.Checkpoint{
 			Epoch: 0,
-			Root:  spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+			Root:  phase0.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
 		},
-		Target: &spec.Checkpoint{
+		Target: &phase0.Checkpoint{
 			Epoch: 1,
-			Root:  spec.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
+			Root:  phase0.Root{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2},
 		},
 	}
 

--- a/types/testingutils/beacon_node_committee_duty.go
+++ b/types/testingutils/beacon_node_committee_duty.go
@@ -221,18 +221,19 @@ var TestingSignedCommitteeBeaconObjectSSZRoot = func(duty *types.CommitteeDuty, 
 
 		ks := ksMap[validatorDuty.ValidatorIndex]
 
-		if validatorDuty.Type == types.BNRoleAttester {
+		switch validatorDuty.Type {
+		case types.BNRoleAttester:
 
 			attResponse := TestingAttestationResponseBeaconObjectForDuty(ks, version, validatorDuty)
 			ret = append(ret, GetSSZRootNoError(attResponse))
-		} else if validatorDuty.Type == types.BNRoleSyncCommittee {
+		case types.BNRoleSyncCommittee:
 			ret = append(ret, GetSSZRootNoError(&altair.SyncCommitteeMessage{
 				Slot:            validatorDuty.Slot,
 				BeaconBlockRoot: TestingBlockRoot,
 				ValidatorIndex:  validatorDuty.ValidatorIndex,
 				Signature:       signBeaconObject(types.SSZBytes(TestingBlockRoot[:]), types.DomainSyncCommittee, ks),
 			}))
-		} else {
+		default:
 			panic(fmt.Sprintf("type %v not expected", validatorDuty.Type))
 		}
 	}

--- a/types/testingutils/ssv_msgs_committee_duty.go
+++ b/types/testingutils/ssv_msgs_committee_duty.go
@@ -41,7 +41,8 @@ var PostConsensusCommitteeMsgForDuty = func(duty *types.CommitteeDuty, keySetMap
 
 		ks := keySetMap[validatorDuty.ValidatorIndex]
 
-		if validatorDuty.Type == types.BNRoleAttester {
+		switch validatorDuty.Type {
+		case types.BNRoleAttester:
 			attData := TestingAttestationDataForValidatorDuty(validatorDuty)
 			pSigMsgs := postConsensusAttestationMsgForAttestationData(ks.Shares[id], id, duty.Slot, attData, validatorDuty.ValidatorIndex)
 			if ret == nil {
@@ -49,14 +50,14 @@ var PostConsensusCommitteeMsgForDuty = func(duty *types.CommitteeDuty, keySetMap
 			} else {
 				ret.Messages = append(ret.Messages, pSigMsgs.Messages...)
 			}
-		} else if validatorDuty.Type == types.BNRoleSyncCommittee {
+		case types.BNRoleSyncCommittee:
 			pSigMsgs := postConsensusSyncCommitteeMsg(ks.Shares[id], id, duty.Slot, false, false, validatorDuty.ValidatorIndex)
 			if ret == nil {
 				ret = pSigMsgs
 			} else {
 				ret.Messages = append(ret.Messages, pSigMsgs.Messages...)
 			}
-		} else {
+		default:
 			panic(fmt.Sprintf("type %v not expected", validatorDuty.Type))
 		}
 	}

--- a/types/testingutils/validator_pubkeys.go
+++ b/types/testingutils/validator_pubkeys.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
-var TestingValidatorPubKeyForValidatorIndex = func(ValidatorIndex phase0.ValidatorIndex) spec.BLSPubKey {
+var TestingValidatorPubKeyForValidatorIndex = func(ValidatorIndex phase0.ValidatorIndex) phase0.BLSPubKey {
 	ks, exists := TestingKeySetMap[ValidatorIndex]
 	if !exists {
 		panic(fmt.Sprintf("Validator index %v does not exist in TestingKeySetMap", ValidatorIndex))
@@ -16,13 +15,13 @@ var TestingValidatorPubKeyForValidatorIndex = func(ValidatorIndex phase0.Validat
 	pk := ks.ValidatorPK
 	pkHexString := pk.SerializeToHexStr()
 	pkString, _ := hex.DecodeString(pkHexString)
-	blsPK := spec.BLSPubKey{}
+	blsPK := phase0.BLSPubKey{}
 	copy(blsPK[:], pkString)
 	return blsPK
 }
 
-var TestingValidatorPubKeyList = func() []spec.BLSPubKey {
-	ret := make([]spec.BLSPubKey, len(TestingKeySetMap))
+var TestingValidatorPubKeyList = func() []phase0.BLSPubKey {
+	ret := make([]phase0.BLSPubKey, len(TestingKeySetMap))
 	listIndex := 0
 	for valIdx := range TestingKeySetMap {
 		pk := TestingValidatorPubKeyForValidatorIndex(valIdx)


### PR DESCRIPTION
## Overview

`Round` was set by test cases but wasn't used by the `CreateMsgSpecTest` processing function in commit messages tests.
This PR adds the `Round` to the `qbft.State` so that it's used in the message creation. 

Closes https://github.com/ssvlabs/ssv-spec/issues/534