### PR TITLE
Adds stale PR and issue labeling workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: 'Label stale PRs and Issues'
+on:
+  schedule:
+    # Runs at 1:30 AM every day
+    - cron: '30 1 * * *'
+  workflow_dispatch: # Allows manual triggering
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9.1.0
+        with:
+          days-before-stale: 60
+          days-before-close: -1
+          stale-pr-message: 'This pull request has been marked as stale due to 60 days of inactivity.'
+          stale-issue-message: 'This issue has been marked as stale due to 60 days of inactivity.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          operations-per-run: 100
+          # Enable statistics in the logs
+          enable-statistics: true


### PR DESCRIPTION
Implements a GitHub Actions workflow that automatically labels pull requests and issues as stale after 60 days of inactivity.
It will post a message and apply a 'stale' label.
The workflow runs daily and can be manually triggered.
